### PR TITLE
Add login and logout views, plus one authenticated view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ before_install:
 install: true
 script:
   - docker-compose exec ${SERVICE_NAME} pre-commit run --all-files --show-diff-on-failure
+  - docker-compose exec ${SERVICE_NAME} coverage run manage.py test

--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -117,3 +117,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "logged-in"

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -15,7 +15,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.contrib.auth.views import LoginView, LogoutView
+
+from assign_rights.views import LoggedInView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('login/', LoginView.as_view(template_name="users/login.html"), name="login"),
+    path('logout/', LogoutView.as_view(next_page="/login"), name="logout"),
+    path('logged-in', LoggedInView.as_view(), name="logged-in")
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -13,11 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path
-from django.contrib.auth.views import LoginView, LogoutView
-
 from assign_rights.views import LoggedInView
+from django.contrib import admin
+from django.contrib.auth.views import LoginView, LogoutView
+from django.urls import path
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/assign_rights/templates/base.html
+++ b/assign_rights/templates/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% block extra_css %}{% endblock %}
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="content-wrapper">
+        <!-- Content Header (Page header) -->
+        <section class="content-header">
+          <h1>{% block h1_title %}{% endblock %}</h1>
+        </section>
+        <!-- Main content -->
+        <main class="content">
+          {% block content %}{% endblock %}
+        </main>
+      </div>
+    </div>
+  </body>
+</html>

--- a/assign_rights/templates/users/logged_in.html
+++ b/assign_rights/templates/users/logged_in.html
@@ -1,0 +1,5 @@
+{% block content %}
+<p>You are now logged in!</p>
+
+<a href="{% url 'logout' %}">Log out</a>
+{% endblock %}

--- a/assign_rights/templates/users/login.html
+++ b/assign_rights/templates/users/login.html
@@ -1,0 +1,23 @@
+{% block content %}
+  <form action="." method="post">
+    {{ form.non_field_errors }}
+
+    {% csrf_token %}
+
+    <div class="form-group has-feedback">
+      {{ form.username.errors }}
+      <input type="text" name="username" id="{{ form.username.id_for_label }}" class="form-control" placeholder="Username" value="{% if form.username.value %}{{ form.username.value }}{% endif %}" />
+    </div>
+    <div class="form-group has-feedback">
+      {{ form.password.errors}}
+      <input name="password" id="{{ form.password.id_for_label }}" type="password" class="form-control" placeholder="Password" value="{% if form.password.value %}{{ form.password.value }}{% endif %}" />
+    </div>
+    <div class="row">
+      <!-- /.col -->
+      <div class="col-xs-4">
+        <button type="submit" class="btn btn-primary btn-block">Sign In</button>
+      </div>
+      <!-- /.col -->
+    </div>
+  </form>
+{% endblock %}

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -1,3 +1,30 @@
-# from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import User
+from .views import LoggedInView
+
+
+class TestAssignRightsViews(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user("test", "test@example.com", "testpass")
+        self.factory = RequestFactory()
+
+    def test_restricted_views(self):
+        """Asserts that restricted views are only available to logged-in users."""
+        restricted_views = [("logged-in", LoggedInView)]
+        for view_name, view in restricted_views:
+            request = self.factory.get(reverse(view_name))
+            request.user = AnonymousUser()
+            response = LoggedInView.as_view()(request)
+            self.assertEqual(
+                response.status_code, 302,
+                "Restricted view {} available without authentication".format(view))
+
+            request.user = self.user
+            authenticated_response = LoggedInView.as_view()(request)
+            self.assertEqual(
+                authenticated_response.status_code, 200,
+                "Restricted view {} not reachable by authenticated user".format(view))

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,5 +1,8 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
-from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView, TemplateView
+
+from assign_rights.models import User
 
 
 def RightsShellsListView(ListView):
@@ -40,3 +43,7 @@ def GroupingsDetailView(DetailView):
 def GroupingsUpdateView(UpdateView):
     '''update grouping'''
     pass
+
+
+class LoggedInView(LoginRequiredMixin, TemplateView):
+    template_name = "users/logged_in.html"

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,8 +1,8 @@
+from assign_rights.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
-from django.views.generic import CreateView, DetailView, ListView, UpdateView, TemplateView
-
-from assign_rights.models import User
+from django.views.generic import (CreateView, DetailView, ListView,
+                                  TemplateView, UpdateView)
 
 
 def RightsShellsListView(ListView):


### PR DESCRIPTION
In order to test this:

1. Bring the app up (making sure migrations run)
2. Navigate to http://localhost:8000/logged-in and observe that you are redirected to http://localhost:8000/login. This is a result of the `LoginRequiredMixin` applied to the `LoggedInView`.
3. In a separate terminal, open up the Django shell and create a user.
```
docker-compose exec aquila-web python manage.py shell
from assign_rights.models import User
User.objects.create_user("test", "test@example.com", "testpassword")
```
4. Navigate to http://localhost:8000/login and enter the username and password from the user you created above. You should be redirected to http://localhost:8000/logged-in
5. Using the link on that page, log out. You should be redirected to http://localhost:8000/login.

A couple of notes on this:
- I added a `base.html` template which provides a slot for a content block, but will need to be updated.
- The `LoggedInView` is for purposes of demonstration only, and will need to be replaced with a dashboard or some other view.
- I've added tests in a `TestAssignRightsViews` class.

fixes #11 