### PR TITLE
Loops through a post request and gets a matching rights_shell to the request's identifier

### DIFF
--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -13,11 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from assign_rights.views import RightsAssemblerView
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-
-from assign_rights.views import RightsAssemblerView
 
 router = routers.DefaultRouter()
 

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from rest_framework import routers
 
 from assign_rights.views import RightsAssemblerView
@@ -24,5 +24,5 @@ router = routers.DefaultRouter()
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include(router.urls)),
-    path('api/rights-assemble/', RightsAssembler.as_view(), name='rights-assemble')
+    path('api/rights-assemble/', RightsAssemblerView.as_view(), name='rights-assemble')
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -16,12 +16,8 @@ Including another URLconf
 from assign_rights.views import RightsAssemblerView
 from django.contrib import admin
 from django.urls import include, path
-from rest_framework import routers
-
-router = routers.DefaultRouter()
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include(router.urls)),
     path('api/rights-assemble/', RightsAssemblerView.as_view(), name='rights-assemble')
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -15,7 +15,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from rest_framework import routers
+
+from assign_rights.views import RightsAssemblerView
+
+router = routers.DefaultRouter()
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include(router.urls)),
+    path('api/rights-assemble/', RightsAssembler.as_view(), name='rights-assemble')
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from assign_rights.views import RightsAssemblerView
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import path
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -8,10 +8,12 @@ from .models import RightsShell
 class RightsAssembler(object):
     """docstring for RightsCalculator"""
 
-    def retrieve_rights(self, item):
+    def retrieve_rights(self, item, shell_list):
         """docstring for retrieve_rights"""
-        shell = RightsShell.objects.get(rights_id=id)
-        return shell
+        identifier = item.get("identifier")
+        shell = RightsShell.objects.get(rights_id=identifier)
+        shell_list.append(shell)
+        return shell_list
 
     def calculate_dates(self):
         """docstring for calculate_dates"""
@@ -26,9 +28,10 @@ class RightsAssembler(object):
     pass
 
     def run(self, request_list):
+        shell_list = []
         for item in request_list:
             try:
-                self.retrieve_rights(item)
-                return 'test'
+                self.retrieve_rights(item, shell_list)
             except Exception as e:
-                print("Could not find matching Rights Shell")
+                print("Error retrieving rights shell: {}".format(str(e)))
+        print(shell_list)

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -12,7 +12,7 @@ class RightsAssembler(object):
         """Retrieves a rights shell whose rights_id matches an identifier from
         a post request.
         """
-        return RightsShell.objects.get(rights_id=identifier)
+        return RightsShell.objects.get(pk=identifier)
 
     def calculate_dates(self):
         """docstring for calculate_dates"""

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -14,11 +14,7 @@ class RightsAssembler(object):
         """
         rights_shells = []
         for ident in rights_ids:
-            try:
-                rights_shells.append(RightsShell.objects.get(pk=ident))
-            except RightsShell.DoesNotExist:
-                error = "Could not find matching shell with identifier: {}".format(str(ident))
-                print(error)
+            rights_shells.append(RightsShell.objects.get(pk=ident))
         return rights_shells
 
     def calculate_dates(self, end_date):
@@ -38,5 +34,5 @@ class RightsAssembler(object):
             rights_shells = self.retrieve_rights(rights_ids)
             for shell in rights_shells:
                 self.calculate_dates(end_date)
-        except Exception as e:
+        except RightsShell.DoesNotExist as e:
             print("Error retrieving rights shell: {}".format(str(e)))

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from .models import RightsShell
 
 # Receive POST request that contains multiple rights IDs and one date
@@ -8,13 +9,22 @@ from .models import RightsShell
 class RightsAssembler(object):
     """docstring for RightsCalculator"""
 
-    def retrieve_rights(self, identifier):
+    def retrieve_rights(self, rights_ids):
         """Retrieves a rights shell whose rights_id matches an identifier from
         a post request.
         """
-        return RightsShell.objects.get(pk=identifier)
+        rights_shells = []
+        for ident in rights_ids:
+            try:
+                rights_shells.append(RightsShell.objects.get(pk=ident))
+            except RightsShell.DoesNotExist:
+                error = "Could not find matching shell with identifier: {}".format(
+                str(ident)
+                )
+                print(error)
+        return rights_shells
 
-    def calculate_dates(self):
+    def calculate_dates(self, end_date):
         """docstring for calculate_dates"""
     pass
 
@@ -27,10 +37,9 @@ class RightsAssembler(object):
     pass
 
     def run(self, rights_ids, end_date):
-        shells = []
-        for identifier in rights_ids:
-            try:
-                shells.append(self.retrieve_rights(identifier))
-            except Exception as e:
-                print("Error retrieving rights shell: {}".format(str(e)))
-        return shells
+        try:
+            rights_shells = self.retrieve_rights(rights_ids)
+            for shell in rights_shells:
+                self.calculate_dates(end_date)
+        except Exception as e:
+            print("Error retrieving rights shell: {}".format(str(e)))

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -10,8 +10,6 @@ class RightsAssembler(object):
 
     def retrieve_rights(self, item):
         """docstring for retrieve_rights"""
-        id = 1
-        print(RightsShell.objects.all())
         shell = RightsShell.objects.get(rights_id=id)
         return shell
 
@@ -29,5 +27,8 @@ class RightsAssembler(object):
 
     def run(self, request_list):
         for item in request_list:
-            self.retrieve_rights(item)
-            return 'test'
+            try:
+                self.retrieve_rights(item)
+                return 'test'
+            except Exception as e:
+                print("Could not find matching Rights Shell")

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -6,11 +6,10 @@
 class RightsAssembler(object):
     """docstring for RightsCalculator"""
 
-    def retrieve_rights(self):
+    def retrieve_rights(self, item):
         """docstring for retrieve_rights"""
-        for id in request:
-            shell = RightsShell.objects.get(rights_id=id)
-            pass
+        shell = RightsShell.objects.get(rights_id=id)
+        return shell
 
     def calculate_dates(self):
         """docstring for calculate_dates"""
@@ -23,3 +22,8 @@ class RightsAssembler(object):
     def return_rights(self):
         """docstring for return_rights"""
     pass
+
+    def run(self, request_list):
+        for item in request_list:
+            self.retrieve_rights(item)
+            return 'test'

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from .models import RightsShell
 
 # Receive POST request that contains multiple rights IDs and one date
@@ -33,4 +34,4 @@ class RightsAssembler(object):
                 shells.append(self.retrieve_rights(identifier))
             except Exception as e:
                 print("Error retrieving rights shell: {}".format(str(e)))
-        print(shells)
+        return shells

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -8,7 +8,9 @@ class RightsAssembler(object):
 
     def retrieve_rights(self):
         """docstring for retrieve_rights"""
-    pass
+        for id in request:
+            shell = RightsShell.objects.get(rights_id=id)
+            pass
 
     def calculate_dates(self):
         """docstring for calculate_dates"""

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -1,3 +1,5 @@
+from .models import RightsShell
+
 # Receive POST request that contains multiple rights IDs and one date
 # For each rights ID, take date to calculate and return rights json (that looks like what Aurora returns)
 # Send rights json back
@@ -8,6 +10,8 @@ class RightsAssembler(object):
 
     def retrieve_rights(self, item):
         """docstring for retrieve_rights"""
+        id = 1
+        print(RightsShell.objects.all())
         shell = RightsShell.objects.get(rights_id=id)
         return shell
 

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -26,9 +26,9 @@ class RightsAssembler(object):
         """docstring for return_rights"""
     pass
 
-    def run(self, request_list):
+    def run(self, rights_ids, end_date):
         shells = []
-        for identifier in request_list.get('identifiers'):
+        for identifier in rights_ids:
             try:
                 shells.append(self.retrieve_rights(identifier))
             except Exception as e:

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ObjectDoesNotExist
 from .models import RightsShell
 
 # Receive POST request that contains multiple rights IDs and one date
@@ -18,9 +17,7 @@ class RightsAssembler(object):
             try:
                 rights_shells.append(RightsShell.objects.get(pk=ident))
             except RightsShell.DoesNotExist:
-                error = "Could not find matching shell with identifier: {}".format(
-                str(ident)
-                )
+                error = "Could not find matching shell with identifier: {}".format(str(ident))
                 print(error)
         return rights_shells
 

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -8,11 +8,10 @@ from .models import RightsShell
 class RightsAssembler(object):
     """docstring for RightsCalculator"""
 
-    def retrieve_rights(self, item):
+    def retrieve_rights(self, identifier):
         """Retrieves a rights shell whose rights_id matches an identifier from
         a post request.
         """
-        identifier = item.get("identifier")
         return RightsShell.objects.get(rights_id=identifier)
 
     def calculate_dates(self):
@@ -29,9 +28,9 @@ class RightsAssembler(object):
 
     def run(self, request_list):
         shells = []
-        for item in request_list:
+        for identifier in request_list.get('identifiers'):
             try:
-                shells.append(self.retrieve_rights(item))
+                shells.append(self.retrieve_rights(identifier))
             except Exception as e:
                 print("Error retrieving rights shell: {}".format(str(e)))
         print(shells)

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -1,4 +1,3 @@
-from django.http import Http404
 from .models import RightsShell
 
 # Receive POST request that contains multiple rights IDs and one date

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -8,12 +8,12 @@ from .models import RightsShell
 class RightsAssembler(object):
     """docstring for RightsCalculator"""
 
-    def retrieve_rights(self, item, shell_list):
-        """docstring for retrieve_rights"""
+    def retrieve_rights(self, item):
+        """Retrieves a rights shell whose rights_id matches an identifier from
+        a post request.
+        """
         identifier = item.get("identifier")
-        shell = RightsShell.objects.get(rights_id=identifier)
-        shell_list.append(shell)
-        return shell_list
+        return RightsShell.objects.get(rights_id=identifier)
 
     def calculate_dates(self):
         """docstring for calculate_dates"""
@@ -28,10 +28,10 @@ class RightsAssembler(object):
     pass
 
     def run(self, request_list):
-        shell_list = []
+        shells = []
         for item in request_list:
             try:
-                self.retrieve_rights(item, shell_list)
+                shells.append(self.retrieve_rights(item))
             except Exception as e:
                 print("Error retrieving rights shell: {}".format(str(e)))
-        print(shell_list)
+        print(shells)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -9,6 +9,7 @@ from .views import RightsAssemblerView
 class TestViews(TestCase):
 
     def setUp(self):
+        self.factory = APIRequestFactory()
         return RightsShell.objects.create(
             rights_id=1,
             rights_basis="Copyright",
@@ -24,7 +25,7 @@ class TestViews(TestCase):
             statute_citation=None
         )
 
-    def test_rightsassemblerview(self):
-        factory = APIRequestFactory()
-        request = factory.post(reverse('rights-assemble'), {"identifiers": [1, 2, 3, 4], "end_date": "2020-03-01"}, format='json')
+    def test_rightsassembler_pass(self):
+        request = self.factory.post(reverse('rights-assemble'), {"identifiers": [1, 2, 3, 4], "end_date": "2020-03-01"}, format='json')
         response = RightsAssemblerView.as_view()(request)
+        self.assertEqual(response.status_code, 200)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
 from .assemble import RightsAssembler
@@ -9,4 +10,4 @@ class TestViews(TestCase):
     def test_rightsassemblerview(self):
         factory = APIRequestFactory()
         request = factory.post(reverse('rights-assemble'), {"items": ["/repositories/2/archival_objects/8457"]}, format='json')
-        response = ProcessRequestView.as_view()(request)
+        response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -1,3 +1,12 @@
-# from django.test import TestCase
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
 
-# Create your tests here.
+from .assemble import RightsAssembler
+from .views import RightsAssemblerView
+
+class TestViews(TestCase):
+
+    def test_rightsassemblerview(self):
+        factory = APIRequestFactory()
+        request = factory.post(reverse('rights-assemble'), {"items": ["/repositories/2/archival_objects/8457"]}, format='json')
+        response = ProcessRequestView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -9,5 +9,5 @@ class TestViews(TestCase):
 
     def test_rightsassemblerview(self):
         factory = APIRequestFactory()
-        request = factory.post(reverse('rights-assemble'), {"items": ["/repositories/2/archival_objects/8457"]}, format='json')
+        request = factory.post(reverse('rights-assemble'), {"items": [1,2,3]}, format='json')
         response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -1,9 +1,26 @@
+import random
+import string
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
+from .assemble import RightsAssembler
 from .models import RightsShell
 from .views import RightsAssemblerView
+
+
+def random_date():
+    now = date.today()
+    r = now - relativedelta(years=random.randint(2, 50))
+    return r.isoformat()
+
+
+def random_string(length=20):
+    """Returns a random string of specified length."""
+    return "".join(random.choice(string.ascii_letters) for m in range(length))
 
 
 class TestViews(TestCase):
@@ -29,3 +46,38 @@ class TestViews(TestCase):
         request = self.factory.post(reverse('rights-assemble'), {"identifiers": [1, 2, 3, 4], "end_date": "2020-03-01"}, format='json')
         response = RightsAssemblerView.as_view()(request)
         self.assertEqual(response.status_code, 200)
+
+
+class TestRightsAssembler(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        for x in range(5):
+            RightsShell.objects.create(
+                rights_id=random.randint(1, 10),
+                rights_basis=random.choice(["Copyright", "Statute", "License", "Other"]),
+                copyright_status="copyrighted",
+                determination_date=random_date(),
+                note=random_string(),
+                applicable_start_date=random_date(),
+                applicable_end_date=random_date(),
+                start_date_period=None,
+                end_date_period=random.randint(0, 10),
+                end_date_open=False,
+                license_terms=None,
+                statute_citation=None
+            )
+            self.assembler = RightsAssembler()
+
+    def test_retrieve_rights(self):
+        """Tests the retrieve_rights method.
+
+        Asserts the method returns a list or DoesNotExist exception.
+        """
+        rights_ids = [obj.pk for obj in RightsShell.objects.all()]
+        assembled = self.assembler.retrieve_rights(rights_ids)
+        self.assertTrue(isinstance(assembled, list))
+        self.assertEqual(len(rights_ids), len(assembled))
+
+        rights_ids.append(len(rights_ids) + 1)
+        with self.assertRaises(RightsShell.DoesNotExist):
+            assembled = self.assembler.retrieve_rights(rights_ids)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -3,11 +3,36 @@ from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
 from .assemble import RightsAssembler
+from .models import RightsShell
 from .views import RightsAssemblerView
+
+
+class TestModels(TestCase):
+
+    def create_rightsshell(self):
+        return RightsShell.objects.create(
+            rights_id = 1,
+            rights_basis = "Copyright",
+            copyright_status = "copyrighted",
+            determination_date = "2020-01-01",
+            note = "note",
+            applicable_start_date = "2019-02-01",
+            applicable_end_date = "2019-03-01",
+            start_date_period = None,
+            end_date_period = None,
+            end_date_open = False,
+            license_terms = None,
+            statute_citation = None
+        )
+
+    def test_rightsshell_creation(self):
+        s = self.create_rightsshell()
+        self.assertTrue(isinstance(s, RightsShell))
 
 class TestViews(TestCase):
 
     def test_rightsassemblerview(self):
+        TestModels.create_rightsshell(self)
         factory = APIRequestFactory()
-        request = factory.post(reverse('rights-assemble'), {"items": [1,2,3]}, format='json')
+        request = factory.post(reverse('rights-assemble'), {"objects":[{"identifier":1,"start_date":"2019-12-09","end_date":"2020-01-01"},{"identifier":2,"start_date":"2019-12-01","end_date":"2020-02-01"},{"identifier":3,"start_date":"2019-11-09","end_date":"2020-03-01"}]}, format='json')
         response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
-ffrom django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -34,5 +34,5 @@ class TestViews(TestCase):
     def test_rightsassemblerview(self):
         TestModels.create_rightsshell(self)
         factory = APIRequestFactory()
-        request = factory.post(reverse('rights-assemble'), {"objects": [{"identifier": 1, "start_date": "2019-12-09", "end_date": "2020-01-01"}, {"identifier": 2, "start_date": "2019-12-01", "end_date": "2020-02-01"}, {"identifier": 3, "start_date": "2019-11-09", "end_date": "2020-03-01"}]}, format='json')
+        request = factory.post(reverse('rights-assemble'), {"identifiers": [1, 2, 3, 4], "end_date": "2020-03-01"}, format='json')
         response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -6,9 +6,9 @@ from .models import RightsShell
 from .views import RightsAssemblerView
 
 
-class TestModels(TestCase):
+class TestViews(TestCase):
 
-    def create_rightsshell(self):
+    def setUp(self):
         return RightsShell.objects.create(
             rights_id=1,
             rights_basis="Copyright",
@@ -24,15 +24,7 @@ class TestModels(TestCase):
             statute_citation=None
         )
 
-    def test_rightsshell_creation(self):
-        s = self.create_rightsshell()
-        self.assertTrue(isinstance(s, RightsShell))
-
-
-class TestViews(TestCase):
-
     def test_rightsassemblerview(self):
-        TestModels.create_rightsshell(self)
         factory = APIRequestFactory()
         request = factory.post(reverse('rights-assemble'), {"identifiers": [1, 2, 3, 4], "end_date": "2020-03-01"}, format='json')
         response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIRequestFactory
 
-from .assemble import RightsAssembler
 from .models import RightsShell
 from .views import RightsAssemblerView
 
@@ -11,28 +10,29 @@ class TestModels(TestCase):
 
     def create_rightsshell(self):
         return RightsShell.objects.create(
-            rights_id = 1,
-            rights_basis = "Copyright",
-            copyright_status = "copyrighted",
-            determination_date = "2020-01-01",
-            note = "note",
-            applicable_start_date = "2019-02-01",
-            applicable_end_date = "2019-03-01",
-            start_date_period = None,
-            end_date_period = None,
-            end_date_open = False,
-            license_terms = None,
-            statute_citation = None
+            rights_id=1,
+            rights_basis="Copyright",
+            copyright_status="copyrighted",
+            determination_date="2020-01-01",
+            note="note",
+            applicable_start_date="2019-02-01",
+            applicable_end_date="2019-03-01",
+            start_date_period=None,
+            end_date_period=None,
+            end_date_open=False,
+            license_terms=None,
+            statute_citation=None
         )
 
     def test_rightsshell_creation(self):
         s = self.create_rightsshell()
         self.assertTrue(isinstance(s, RightsShell))
 
+
 class TestViews(TestCase):
 
     def test_rightsassemblerview(self):
         TestModels.create_rightsshell(self)
         factory = APIRequestFactory()
-        request = factory.post(reverse('rights-assemble'), {"objects":[{"identifier":1,"start_date":"2019-12-09","end_date":"2020-01-01"},{"identifier":2,"start_date":"2019-12-01","end_date":"2020-02-01"},{"identifier":3,"start_date":"2019-11-09","end_date":"2020-03-01"}]}, format='json')
+        request = factory.post(reverse('rights-assemble'), {"objects": [{"identifier": 1, "start_date": "2019-12-09", "end_date": "2020-01-01"}, {"identifier": 2, "start_date": "2019-12-01", "end_date": "2020-02-01"}, {"identifier": 3, "start_date": "2019-11-09", "end_date": "2020-03-01"}]}, format='json')
         response = RightsAssemblerView.as_view()(request)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -54,4 +54,4 @@ class RightsAssemblerView(APIView):
         rights_ids = request.data.get("identifiers")
         end_date = request.data.get("end_date")
         assembled = RightsAssembler().run(rights_ids, end_date)
-        return Response(assembled, status=200)
+        return Response(assembled)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .assemble import RightsAssembler
@@ -52,4 +53,4 @@ class RightsAssemblerView(APIView):
         request_list = request.data.get('items')
         shell_list = RightsAssembler().run(request_list)
         print(shell_list)
-        return Response(process_list, status=200)
+        return Response(request_list, status=200)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -45,10 +45,12 @@ class GroupingsUpdateView(UpdateView):
     '''update grouping'''
     pass
 
+
 class RightsAssemblerView(APIView):
     '''
     Calls the RightsAssembler class from assemblers.
     '''
+
     def post(self, request, format=None):
         request_list = request.data.get('objects')
         shell_list = RightsAssembler().run(request_list)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -50,6 +50,6 @@ class RightsAssemblerView(APIView):
     '''
     def post(self, request, format=None):
         request_list = request.data.get('items')
-        shell_list = RightsAssembler().run(object_list)
+        shell_list = RightsAssembler().run(request_list)
         print(shell_list)
         return Response(process_list, status=200)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -2,27 +2,27 @@ from django.shortcuts import render
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
-def RightsShellsListView(ListView):
+class RightsShellsListView(ListView):
     '''browse and search rights shells'''
     pass
 
 
-def RightsShellsCreateView(CreateView):
+class RightsShellsCreateView(CreateView):
     '''create rights shells'''
     pass
 
 
-def RightsShellsDetailView(DetailView):
+class RightsShellsDetailView(DetailView):
     '''view a rights shell'''
     pass
 
 
-def RightsShellsUpdateView(UpdateView):
+class RightsShellsUpdateView(UpdateView):
     '''update rights shell'''
     pass
 
 
-def GroupingsListView(ListView):
+class GroupingsListView(ListView):
     '''browse and search groupings'''
     pass
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -51,6 +51,7 @@ class RightsAssemblerView(APIView):
     '''
 
     def post(self, request, format=None):
-        request_list = request.data
-        shell_list = RightsAssembler().run(request_list)
-        return Response(request_list, status=200)
+        rights_ids = request.data.get("identifiers")
+        end_date = request.data.get("end_date")
+        assembled = RightsAssembler().run(rights_ids, end_date)
+        return Response(assembled, status=200)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -50,7 +50,6 @@ class RightsAssemblerView(APIView):
     Calls the RightsAssembler class from assemblers.
     '''
     def post(self, request, format=None):
-        request_list = request.data.get('items')
+        request_list = request.data.get('objects')
         shell_list = RightsAssembler().run(request_list)
-        print(shell_list)
         return Response(request_list, status=200)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -5,22 +5,22 @@ from rest_framework.views import APIView
 from .assemble import RightsAssembler
 
 
-class RightsShellsListView(ListView):
+class RightsShellListView(ListView):
     '''browse and search rights shells'''
     pass
 
 
-class RightsShellsCreateView(CreateView):
+class RightsShellCreateView(CreateView):
     '''create rights shells'''
     pass
 
 
-class RightsShellsDetailView(DetailView):
+class RightsShellDetailView(DetailView):
     '''view a rights shell'''
     pass
 
 
-class RightsShellsUpdateView(UpdateView):
+class RightsShellUpdateView(UpdateView):
     '''update rights shell'''
     pass
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -52,6 +51,6 @@ class RightsAssemblerView(APIView):
     '''
 
     def post(self, request, format=None):
-        request_list = request.data.get('objects')
+        request_list = request.data
         shell_list = RightsAssembler().run(request_list)
         return Response(request_list, status=200)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,5 +1,8 @@
 from django.shortcuts import render
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from rest_framework.views import APIView
+
+from .assemble import RightsAssembler
 
 
 class RightsShellsListView(ListView):
@@ -27,16 +30,26 @@ class GroupingsListView(ListView):
     pass
 
 
-def GroupingsCreateView(CreateView):
+class GroupingsCreateView(CreateView):
     '''create groupings'''
     pass
 
 
-def GroupingsDetailView(DetailView):
+class GroupingsDetailView(DetailView):
     '''view a grouping'''
     pass
 
 
-def GroupingsUpdateView(UpdateView):
+class GroupingsUpdateView(UpdateView):
     '''update grouping'''
     pass
+
+class RightsAssemblerView(APIView):
+    '''
+    Calls the RightsAssembler class from assemblers.
+    '''
+    def post(self, request, format=None):
+        request_list = request.data.get('items')
+        shell_list = RightsAssembler().run(object_list)
+        print(shell_list)
+        return Response(process_list, status=200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,14 @@
+clinner==1.12.3
+colorlog==3.2.0
 Django==2.2.13
-djangorestframework
-health-check
-psycopg2-binary
+djangorestframework==3.11.0
+gitdb==4.0.5
+GitPython==3.1.3
+health-check==3.4.1
+psycopg2-binary==2.8.5
+python-dateutil==2.8.1
+pytz==2020.1
+PyYAML==5.3.1
+six==1.15.0
+smmap==3.0.4
+sqlparse==0.3.1


### PR DESCRIPTION
Fixes #8 .

Loops through a post request through an API view and looks for each object's identifier. Gets the rights shell that matches that identifier exactly (I'm assuming there should only be one match per identifier/shell), and then appends the shell to a list.

Prints out an exception right now if it cannot match identifiers.

Also includes a first stab at testing one of the models/views.