### PR TITLE
UIs for creating, editing, viewing, and browsing rights statement shells

### DIFF
--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -25,7 +25,7 @@ from django.urls import path
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/rights-assemble/', RightsAssemblerView.as_view(), name='rights-assemble'),
-    path('groupings/', GroupingListView.as_view(), name="groupings-list"),
+    path('', GroupingListView.as_view(), name="groupings-list"),
     path('groupings/<int:pk>/', GroupingDetailView.as_view(), name="groupings-detail"),
     path('groupings/create/', GroupingCreateView.as_view(), name="groupings-create"),
     path('groupings/<int:pk>/update/', GroupingUpdateView.as_view(), name="groupings-update"),

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -34,5 +34,5 @@ urlpatterns = [
     path('rights/', RightsShellListView.as_view(), name='rights-list'),
     path('rights/create/', RightsShellCreateView.as_view(), name='rights-create'),
     path('rights/<int:pk>/update/', RightsShellUpdateView.as_view(), name='rights-update'),
-    path('rights/<int:pk>', RightsShellDetailView.as_view(), name='rights-detail'),
+    path('rights/<int:pk>/', RightsShellDetailView.as_view(), name='rights-detail'),
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path('groupings/', GroupingListView.as_view(), name="groupings-list"),
     path('groupings/<int:pk>/', GroupingDetailView.as_view(), name="groupings-detail"),
     path('groupings/create/', GroupingCreateView.as_view(), name="groupings-create"),
-    path('groupings/<int:pk>/edit/', GroupingUpdateView.as_view(), name="groupings-update"),
+    path('groupings/<int:pk>/update/', GroupingUpdateView.as_view(), name="groupings-update"),
     path('login/', AquilaLoginView.as_view(template_name="users/login.html"), name="login"),
     path('logout/', LogoutView.as_view(next_page="/login"), name="logout"),
     path('rights/', RightsShellListView.as_view(), name='rights-list'),

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -15,7 +15,9 @@ Including another URLconf
 """
 from assign_rights.views import (AquilaLoginView, GroupingCreateView,
                                  GroupingDetailView, GroupingListView,
-                                 GroupingUpdateView, RightsAssemblerView)
+                                 GroupingUpdateView, RightsAssemblerView,
+                                 RightsShellCreateView, RightsShellDetailView,
+                                 RightsShellListView, RightsShellUpdateView)
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import path
@@ -29,4 +31,8 @@ urlpatterns = [
     path('groupings/<int:pk>/edit/', GroupingUpdateView.as_view(), name="groupings-update"),
     path('login/', AquilaLoginView.as_view(template_name="users/login.html"), name="login"),
     path('logout/', LogoutView.as_view(next_page="/login"), name="logout"),
+    path('rights/', RightsShellListView.as_view(), name='rights-list'),
+    path('rights/create/', RightsShellCreateView.as_view(), name='rights-create'),
+    path('rights/<int:pk>/update/', RightsShellUpdateView.as_view(), name='rights-update'),
+    path('rights/<int:pk>', RightsShellDetailView.as_view(), name='rights-detail'),
 ]

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -19,8 +19,8 @@ class RightsShellForm(ModelForm):
             'copyright_status',
             'determination_date',
             'note',
-            'applicable_start_date',
-            'applicable_end_date',
+            'start_date',
+            'end_date',
             'start_date_period',
             'end_date_period',
             'end_date_open',
@@ -35,6 +35,7 @@ class RightsGrantedForm(ModelForm):
         model = RightsGranted
         fields = [
             'basis',
+            'restriction',
             'act',
             'note',
             'start_date',

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -4,14 +4,12 @@ from .models import Grouping, RightsGranted, RightsShell
 
 
 class GroupingForm(ModelForm):
-    """docstring for RightsShellForm"""
     class Meta:
         model = Grouping
         fields = ["title", "description", "rights_shells"]
 
 
 class RightsShellForm(ModelForm):
-    """docstring for RightsShellForm"""
     class Meta:
         model = RightsShell
         fields = [
@@ -30,7 +28,6 @@ class RightsShellForm(ModelForm):
 
 
 class RightsGrantedForm(ModelForm):
-    """docstring for RightsShellForm"""
     class Meta:
         model = RightsGranted
         fields = [

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,10 +1,53 @@
-from django import forms
+from django.forms import ModelForm, inlineformset_factory
 
-from .models import Grouping
+from .models import Grouping, RightsGranted, RightsShell
 
 
-class GroupingForm(forms.ModelForm):
+class GroupingForm(ModelForm):
     """docstring for RightsShellForm"""
     class Meta:
         model = Grouping
         fields = ["title", "description", "rights_shells"]
+
+
+class RightsShellForm(ModelForm):
+    """docstring for RightsShellForm"""
+    class Meta:
+        model = RightsShell
+        fields = [
+            'rights_basis',
+            'copyright_status',
+            'determination_date',
+            'note',
+            'applicable_start_date',
+            'applicable_end_date',
+            'start_date_period',
+            'end_date_period',
+            'end_date_open',
+            'license_terms',
+            'statute_citation'
+        ]
+
+
+class RightsGrantedForm(ModelForm):
+    """docstring for RightsShellForm"""
+    class Meta:
+        model = RightsGranted
+        fields = [
+            'basis',
+            'act',
+            'note',
+            'start_date',
+            'end_date',
+            'start_date_period',
+            'end_date_period',
+            'end_date_open',
+        ]
+
+
+RightsGrantedFormSet = inlineformset_factory(
+    RightsShell,
+    RightsGranted,
+    extra=1,
+    form=RightsGrantedForm,
+)

--- a/assign_rights/models.py
+++ b/assign_rights/models.py
@@ -34,6 +34,9 @@ class RightsShell(models.Model):
     created = models.DateTimeField(auto_now=True)
     last_modified = models.DateTimeField(auto_now_add=True)
 
+    def get_absolute_url(self):
+        return reverse("rights-detail", kwargs={"pk": self.pk})
+
     def __str__(self):
         return "{} ({})".format(self.note, self.rights_basis)
 

--- a/assign_rights/templates/navbar.html
+++ b/assign_rights/templates/navbar.html
@@ -15,7 +15,7 @@
           <a class="nav-link" href="{% url 'groupings-list' %}">Groupings</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#">Rights Shells</a>
+          <a class="nav-link" href="{% url 'rights-list' %}">Rights Shells</a>
         </li>
       </ul>
       <form class="form-inline my-2 my-lg-0">

--- a/assign_rights/templates/rights/create.html
+++ b/assign_rights/templates/rights/create.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<form action="." method="POST" accept-charset="utf-8">
+	{% csrf_token %}
+	{{ form.as_p }}
+      {{ rights_granted.as_p }} 
+	  {{ rights_granted.management_form }} 
+	<p><input type="submit" value="Save"></p>
+</form>
+
+{% endblock %}
+

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -92,6 +92,8 @@
 </tbody>
 </table>
 
+<a class="btn btn-warning" href="{% url 'rights-update' pk=object.pk %}">Edit</a>
+
 
 {% endblock %}
 

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -5,92 +5,89 @@
 <small>Created on {{ rightsshell.created }}</small><br/>
 <small>Last modified on {{ rightsshell.last_modified }}</small>
 
-<table class="table">
-<tbody>
-  <tr>
-    <td>ID</td>
-    <td>{{ rightsshell.pk }}</td>
-  </tr>
-  <tr>
-    <td>Basis</td>
-    <td>{{ rightsshell.rights_basis }}</td>
-  </tr>
-  <tr>
-    <td>Copyright Status</td>
-    <td>{{ rightsshell.copyright_status }}</td>
-  </tr>
-  <tr>
-    <td>Determination Date</td>
-    <td>{{ rightsshell.determination_date }}</td>
-  </tr>
-  <tr>
-    <td>Note</td>
-    <td>{{ rightsshell.note }}</td>
-  </tr>
-  <tr>
-    <td>Start Date</td>
-    <td>{{ rightsshell.start_date }}</td>
-  </tr>
-  <tr>
-    <td>End Date</td>
-    <td>{{ rightsshell.end_date }}</td>
-  </tr>
-  <tr>
-    <td>Start Date Period</td>
-    <td>{{ rightsshell.start_date_period }}</td>
-  </tr>
-  <tr>
-    <td>End Date Period</td>
-    <td>{{ rightsshell.end_date_period }}</td>
-  </tr>
-  <tr>
-    <td>Open End Date</td>
-    <td>{{ rightsshell.end_date_open }}</td>
-  </tr>
-  <tr>
-    <td>License Terms</td>
-    <td>{{ rightsshell.license_terms }}</td>
-  </tr>
-  <tr>
-    <td>Statute Citation</td>
-    <td>{{ rightsshell.statute_citation }}</td>
-  </tr>
+<dl class="row">
+   <dt class="col-sm-3">ID</dt>
+	<dd class="col-sm-3">{{ rightsshell.pk }}</dd>
+</dl> 
+<dl class="row"> 
+   <dt class="col-sm-3">Basis</dt>
+	<dd class="col-sm-3">{{ rightsshell.rights_basis }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Copyright Status</dt>
+	<dd class="col-sm-3">{{ rightsshell.copyright_status }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Determination Date</dt>
+	<dd class="col-sm-3">{{ rightsshell.determination_date }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Note</dt>
+	<dd class="col-sm-3">{{ rightsshell.note }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Start Date</dt>
+	<dd class="col-sm-3">{{ rightsshell.start_date }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">End Date</dt>
+	<dd class="col-sm-3">{{ rightsshell.end_date }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Start Date Period</dt>
+	<dd class="col-sm-3">{{ rightsshell.start_date_period }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">End Date Period</dt>
+	<dd class="col-sm-3">{{ rightsshell.end_date_period }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Open End Date</dt>
+	<dd class="col-sm-3">{{ rightsshell.end_date_open }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">License Terms</dt>
+	<dd class="col-sm-3">{{ rightsshell.license_terms }}</dd>
+</dl> 
+<dl class="row">  
+   <dt class="col-sm-3">Statute Citation</dt>
+	<dd class="col-sm-3">{{ rightsshell.statute_citation }}</dd>
+</dl> 
     {% for acts in rightsshell.rightsgranted_set.all %}
-	<tr>
-		<td>Act</td>
-		<td>{{acts.act}}</td>
-	</tr>
-	<tr>
-		<td>Restriction</td>
-		<td>{{acts.restriction}}</td>
-	</tr>
-	<tr>
-		<td>Act Note</td>
-		<td>{{acts.note}}</td>
-	</tr>
-	<tr>
-		<td>Act Start Date</td>
-		<td>{{acts.start_date}}</td>
-	</tr>
-	<tr>
-		<td>Act End Date</td>
-		<td>{{acts.end_date}}</td>
-	</tr>
-	<tr>
-		<td>Act Start Date Period</td>
-		<td>{{acts.start_date_period}}</td>
-	</tr>
-	<tr>
-		<td>Act End Date Period</td>
-		<td>{{acts.end_date_period}}</td>
-	</tr>
-	<tr>
-		<td>Act Open End Date</td>
-		<td>{{acts.end_date_open}}</td>
-	</tr>
+<dl class="row">  	
+	 <dt class="col-sm-3">Act</dt>
+	<dd class="col-sm-3">{{acts.act}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Restriction</dt>
+	<dd class="col-sm-3">{{acts.restriction}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act Note</dt>
+	<dd class="col-sm-3">{{acts.note}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act Start Date</dt>
+	<dd class="col-sm-3">{{acts.start_date}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act End Date</dt>
+	<dd class="col-sm-3">{{acts.end_date}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act Start Date Period</dt>
+	<dd class="col-sm-3">{{acts.start_date_period}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act End Date Period</dt>
+	<dd class="col-sm-3">{{acts.end_date_period}}</dd>
+</dl> 
+<dl class="row">  	
+	 <dt class="col-sm-3">Act Open End Date</dt>
+	<dd class="col-sm-3">{{acts.end_date_open}}</dd>
+</dl>
+	
 	{% endfor %}
-</tbody>
-</table>
 
 <a class="btn btn-warning" href="{% url 'rights-update' pk=object.pk %}">Edit</a>
 

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -6,94 +6,89 @@
 <small>Last modified on {{ rightsshell.last_modified }}</small>
 
 <dl class="row">
-   <dt class="col-sm-3">ID</dt>
-	<dd class="col-sm-3">{{ rightsshell.pk }}</dd>
-</dl> 
-<dl class="row"> 
-   <dt class="col-sm-3">Basis</dt>
-	<dd class="col-sm-3">{{ rightsshell.rights_basis }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Copyright Status</dt>
-	<dd class="col-sm-3">{{ rightsshell.copyright_status }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Determination Date</dt>
-	<dd class="col-sm-3">{{ rightsshell.determination_date }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Note</dt>
-	<dd class="col-sm-3">{{ rightsshell.note }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Start Date</dt>
-	<dd class="col-sm-3">{{ rightsshell.start_date }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">End Date</dt>
-	<dd class="col-sm-3">{{ rightsshell.end_date }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Start Date Period</dt>
-	<dd class="col-sm-3">{{ rightsshell.start_date_period }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">End Date Period</dt>
-	<dd class="col-sm-3">{{ rightsshell.end_date_period }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Open End Date</dt>
-	<dd class="col-sm-3">{{ rightsshell.end_date_open }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">License Terms</dt>
-	<dd class="col-sm-3">{{ rightsshell.license_terms }}</dd>
-</dl> 
-<dl class="row">  
-   <dt class="col-sm-3">Statute Citation</dt>
-	<dd class="col-sm-3">{{ rightsshell.statute_citation }}</dd>
-</dl> 
-    {% for acts in rightsshell.rightsgranted_set.all %}
-<dl class="row">  	
-	 <dt class="col-sm-3">Act</dt>
-	<dd class="col-sm-3">{{acts.act}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Restriction</dt>
-	<dd class="col-sm-3">{{acts.restriction}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act Note</dt>
-	<dd class="col-sm-3">{{acts.note}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act Start Date</dt>
-	<dd class="col-sm-3">{{acts.start_date}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act End Date</dt>
-	<dd class="col-sm-3">{{acts.end_date}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act Start Date Period</dt>
-	<dd class="col-sm-3">{{acts.start_date_period}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act End Date Period</dt>
-	<dd class="col-sm-3">{{acts.end_date_period}}</dd>
-</dl> 
-<dl class="row">  	
-	 <dt class="col-sm-3">Act Open End Date</dt>
-	<dd class="col-sm-3">{{acts.end_date_open}}</dd>
+  <dt class="col-sm-3">ID</dt>
+  <dd class="col-sm-3">{{ rightsshell.pk }}</dd>
 </dl>
-	
-	{% endfor %}
+<dl class="row">
+  <dt class="col-sm-3">Basis</dt>
+  <dd class="col-sm-3">{{ rightsshell.rights_basis }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Copyright Status</dt>
+  <dd class="col-sm-3">{{ rightsshell.copyright_status }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Determination Date</dt>
+  <dd class="col-sm-3">{{ rightsshell.determination_date }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Note</dt>
+  <dd class="col-sm-3">{{ rightsshell.note }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Start Date</dt>
+  <dd class="col-sm-3">{{ rightsshell.start_date }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">End Date</dt>
+  <dd class="col-sm-3">{{ rightsshell.end_date }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Start Date Period</dt>
+  <dd class="col-sm-3">{{ rightsshell.start_date_period }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">End Date Period</dt>
+  <dd class="col-sm-3">{{ rightsshell.end_date_period }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Open End Date</dt>
+  <dd class="col-sm-3">{{ rightsshell.end_date_open }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">License Terms</dt>
+  <dd class="col-sm-3">{{ rightsshell.license_terms }}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Statute Citation</dt>
+  <dd class="col-sm-3">{{ rightsshell.statute_citation }}</dd>
+</dl>
+
+{% for acts in rightsshell.rightsgranted_set.all %}
+<dl class="row">
+  <dt class="col-sm-3">Act</dt>
+  <dd class="col-sm-3">{{acts.act}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Restriction</dt>
+  <dd class="col-sm-3">{{acts.restriction}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act Note</dt>
+  <dd class="col-sm-3">{{acts.note}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act Start Date</dt>
+  <dd class="col-sm-3">{{acts.start_date}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act End Date</dt>
+  <dd class="col-sm-3">{{acts.end_date}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act Start Date Period</dt>
+  <dd class="col-sm-3">{{acts.start_date_period}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act End Date Period</dt>
+  <dd class="col-sm-3">{{acts.end_date_period}}</dd>
+</dl>
+<dl class="row">
+  <dt class="col-sm-3">Act Open End Date</dt>
+  <dd class="col-sm-3">{{acts.end_date_open}}</dd>
+</dl>
+{% endfor %}
 
 <a class="btn btn-warning" href="{% url 'rights-update' pk=object.pk %}">Edit</a>
 
-
 {% endblock %}
-
-
-
-

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -2,18 +2,96 @@
 
 {% block content %}
 
-<p>{{ rightsshell.pk }} </p>
-<p>{{ rightsshell.rights_basis }} </p>
-<p>{{ rightsshell.copyright_status }} </p>
-<p>{{ rightsshell.determination_date }} </p>
-<p>{{ rightsshell.note }} </p>
-<p>{{ rightsshell.start_date }} </p>
-<p>{{ rightsshell.end_date }} </p>
-<p>{{ rightsshell.start_date_period }} </p>
-<p>{{ rightsshell.end_date_period }} </p>
-<p>{{ rightsshell.end_date_open }} </p>
-<p>{{ rightsshell.license_terms }} </p>
-<p>{{ rightsshell.statute_citation }} </p>
+<small>Created on {{ rightsshell.created }}</small><br/>
+<small>Last modified on {{ rightsshell.last_modified }}</small>
+
+<table class="table">
+<tbody>
+  <tr>
+    <td>ID</td>
+    <td>{{ rightsshell.pk }}</td>
+  </tr>
+  <tr>
+    <td>Basis</td>
+    <td>{{ rightsshell.rights_basis }}</td>
+  </tr>
+  <tr>
+    <td>Copyright Status</td>
+    <td>{{ rightsshell.copyright_status }}</td>
+  </tr>
+  <tr>
+    <td>Determination Date</td>
+    <td>{{ rightsshell.determination_date }}</td>
+  </tr>
+  <tr>
+    <td>Note</td>
+    <td>{{ rightsshell.note }}</td>
+  </tr>
+  <tr>
+    <td>Start Date</td>
+    <td>{{ rightsshell.start_date }}</td>
+  </tr>
+  <tr>
+    <td>End Date</td>
+    <td>{{ rightsshell.end_date }}</td>
+  </tr>
+  <tr>
+    <td>Start Date Period</td>
+    <td>{{ rightsshell.start_date_period }}</td>
+  </tr>
+  <tr>
+    <td>End Date Period</td>
+    <td>{{ rightsshell.end_date_period }}</td>
+  </tr>
+  <tr>
+    <td>Open End Date</td>
+    <td>{{ rightsshell.end_date_open }}</td>
+  </tr>
+  <tr>
+    <td>License Terms</td>
+    <td>{{ rightsshell.license_terms }}</td>
+  </tr>
+  <tr>
+    <td>Statute Citation</td>
+    <td>{{ rightsshell.statute_citation }}</td>
+  </tr>
+    {% for acts in rightsshell.rightsgranted_set.all %}
+	<tr>
+		<td>Act</td>
+		<td>{{acts.act}}</td>
+	</tr>
+	<tr>
+		<td>Restriction</td>
+		<td>{{acts.restriction}}</td>
+	</tr>
+	<tr>
+		<td>Act Note</td>
+		<td>{{acts.note}}</td>
+	</tr>
+	<tr>
+		<td>Act Start Date</td>
+		<td>{{acts.start_date}}</td>
+	</tr>
+	<tr>
+		<td>Act End Date</td>
+		<td>{{acts.end_date}}</td>
+	</tr>
+	<tr>
+		<td>Act Start Date Period</td>
+		<td>{{acts.start_date_period}}</td>
+	</tr>
+	<tr>
+		<td>Act End Date Period</td>
+		<td>{{acts.end_date_period}}</td>
+	</tr>
+	<tr>
+		<td>Act Open End Date</td>
+		<td>{{acts.end_date_open}}</td>
+	</tr>
+	{% endfor %}
+</tbody>
+</table>
+
 
 {% endblock %}
 

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<p>{{ rightsshell.pk }} </p>
+<p>{{ rightsshell.rights_basis }} </p>
+<p>{{ rightsshell.copyright_status }} </p>
+<p>{{ rightsshell.determination_date }} </p>
+<p>{{ rightsshell.note }} </p>
+<p>{{ rightsshell.start_date }} </p>
+<p>{{ rightsshell.end_date }} </p>
+<p>{{ rightsshell.start_date_period }} </p>
+<p>{{ rightsshell.end_date_period }} </p>
+<p>{{ rightsshell.end_date_open }} </p>
+<p>{{ rightsshell.license_terms }} </p>
+<p>{{ rightsshell.statute_citation }} </p>
+
+{% endblock %}
+
+
+
+

--- a/assign_rights/templates/rights/list.html
+++ b/assign_rights/templates/rights/list.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<a class="btn btn-primary mb-2" href="{% url 'rights-create' %}">Create new rights shell</a>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Basis</th>
+      <th scope="col">Note</th>
+	  <th scope="col">Rights Granted or Restricted</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for rightsshell in object_list %}
+    <tr>
+  		<td><a href=' {{ rightsshell.get_absolute_url }}'>{{ rightsshell.pk }}</a></td>
+      <td>{{ rightsshell.rights_basis }}</td>
+      <td>{{ rightsshell.note }}</td>
+      <td>{% for acts in rightsshell.rightsgranted_set.all %} {{acts.act}} - {{acts.restriction}} {% if not forloop.last %}<br/>{% endif %}{% endfor %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/assign_rights/templates/rights/list.html
+++ b/assign_rights/templates/rights/list.html
@@ -9,13 +9,13 @@
       <th scope="col">ID</th>
       <th scope="col">Basis</th>
       <th scope="col">Note</th>
-	  <th scope="col">Rights Granted or Restricted</th>
+      <th scope="col">Rights Granted or Restricted</th>
     </tr>
   </thead>
   <tbody>
     {% for rightsshell in object_list %}
     <tr>
-  		<td><a href=' {{ rightsshell.get_absolute_url }}'>{{ rightsshell.pk }}</a></td>
+      <td><a href=' {{ rightsshell.get_absolute_url }}'>{{ rightsshell.pk }}</a></td>
       <td>{{ rightsshell.rights_basis }}</td>
       <td>{{ rightsshell.note }}</td>
       <td>{% for acts in rightsshell.rightsgranted_set.all %} {{acts.act}} - {{acts.restriction}} {% if not forloop.last %}<br/>{% endif %}{% endfor %}</td>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -5,9 +5,9 @@
 <form action="." method="POST" accept-charset="utf-8">
 	{% csrf_token %}
 	{{ form.as_p }}
-      {{ rights_granted_form.as_p }}
-      {{ rights_granted_form.management_form }} 
-	<p><button type="submit" class="btn btn-primary">Save</button></p>
+	{{ rights_granted_form.as_p }}
+	{{ rights_granted_form.management_form }}
+	<button type="submit" class="btn btn-primary">Save</button>
 </form>
 
 {% endblock %}

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -7,7 +7,7 @@
 	{{ form.as_p }}
       {{ rights_granted.as_p }} 
 	  {{ rights_granted.management_form }} 
-	<p><input type="submit" value="Save"></p>
+	<p><button type="submit" class="btn btn-primary">Save</button></p>
 </form>
 
 {% endblock %}

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -5,10 +5,9 @@
 <form action="." method="POST" accept-charset="utf-8">
 	{% csrf_token %}
 	{{ form.as_p }}
-      {{ rights_granted.as_p }} 
-	  {{ rights_granted.management_form }} 
+      {{ rights_granted_form.as_p }}
+      {{ rights_granted_form.management_form }} 
 	<p><button type="submit" class="btn btn-primary">Save</button></p>
 </form>
 
 {% endblock %}
-

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -13,7 +13,9 @@ from .models import Grouping, RightsShell, User
 from .test_helpers import (add_groupings, add_rights_acts, add_rights_shells,
                            random_date, random_string)
 from .views import (GroupingCreateView, GroupingDetailView, GroupingListView,
-                    GroupingUpdateView)
+                    GroupingUpdateView, RightsShellCreateView,
+                    RightsShellDetailView, RightsShellListView,
+                    RightsShellUpdateView)
 
 
 class TestViews(TestCase):
@@ -126,6 +128,7 @@ class TestAssignRightsViews(TestCase):
         self.user = User.objects.create_user("test", "test@example.com", "testpass")
         self.factory = RequestFactory()
         add_groupings()
+        add_rights_shells()
 
     def test_restricted_views(self):
         """Asserts that restricted views are only available to logged-in users."""
@@ -133,7 +136,11 @@ class TestAssignRightsViews(TestCase):
             ("groupings-list", GroupingListView, None),
             ("groupings-detail", GroupingDetailView, random.choice(Grouping.objects.all()).pk),
             ("groupings-create", GroupingCreateView, False),
-            ("groupings-update", GroupingUpdateView, random.choice(Grouping.objects.all()).pk)]
+            ("groupings-update", GroupingUpdateView, random.choice(Grouping.objects.all()).pk),
+            ("rights-list", RightsShellListView, None),
+            ("rights-detail", RightsShellDetailView, random.choice(RightsShell.objects.all()).pk),
+            ("rights-create", RightsShellCreateView, False),
+            ("rights-update", RightsShellUpdateView, random.choice(RightsShell.objects.all()).pk)]
         for view_name, view, pk in restricted_views:
             request = self.factory.get(reverse(view_name, kwargs={"pk": pk})) if pk else self.factory.get(reverse(view_name))
             request.user = AnonymousUser()

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -93,8 +93,6 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
         else:
             return super().form_invalid(form)
 
-    def get_success_url(self):
-        return reverse_lazy("rights-detail", kwargs={"pk": self.object.pk})
 
 
 class GroupingListView(PageTitleMixin, LoginRequiredMixin, ListView):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -28,17 +28,19 @@ class PageTitleMixin(object):
         return context
 
 
-class RightsShellListView(LoginRequiredMixin, ListView):
+class RightsShellListView(PageTitleMixin, LoginRequiredMixin, ListView):
     '''browse and search rights shells'''
     queryset = RightsShell.objects.all()
     template_name = "rights/list.html"
+    page_title = "Rights"
 
 
-class RightsShellCreateView(LoginRequiredMixin, CreateView):
+class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
     success_url = None
+    page_title = "Create New Rights Shell"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -63,13 +65,16 @@ class RightsShellCreateView(LoginRequiredMixin, CreateView):
         return reverse_lazy("rights-detail", kwargs={"pk": self.object.pk})
 
 
-class RightsShellDetailView(LoginRequiredMixin, DetailView):
+class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
     '''view a rights shell'''
     model = RightsShell
     template_name = "rights/detail.html"
 
+    def get_page_title(self, context):
+        return "Rights Shell {}".format(context["object"].pk)
 
-class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
+
+class RightsShellUpdateView(PageTitleMixin, LoginRequiredMixin, UpdateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
@@ -92,6 +97,9 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
             return response
         else:
             return super().form_invalid(form)
+
+    def get_page_title(self, context):
+        return "Update Rights Shell {}".format(context["object"].pk)
 
 
 class GroupingListView(PageTitleMixin, LoginRequiredMixin, ListView):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -65,7 +65,7 @@ class RightsShellCreateView(LoginRequiredMixin, CreateView):
 
 class RightsShellDetailView(LoginRequiredMixin, DetailView):
     '''view a rights shell'''
-    queryset = RightsShell.objects.all()
+    model = RightsShell
     template_name = "rights/detail.html"
 
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -30,7 +30,7 @@ class PageTitleMixin(object):
 
 class RightsShellListView(PageTitleMixin, LoginRequiredMixin, ListView):
     """Browse and search rights shells."""
-    queryset = RightsShell.objects.all()
+    model = RightsShell
     template_name = "rights/list.html"
     page_title = "Rights"
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -30,7 +30,8 @@ class PageTitleMixin(object):
 
 class RightsShellListView(ListView):
     '''browse and search rights shells'''
-    pass
+    queryset = RightsShell.objects.all()
+    template_name = "rights/list.html"
 
 
 class RightsShellCreateView(CreateView):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -73,7 +73,6 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
-    success_url = None
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -29,13 +29,14 @@ class PageTitleMixin(object):
 
 
 class RightsShellListView(PageTitleMixin, LoginRequiredMixin, ListView):
-    '''browse and search rights shells'''
+    """Browse and search rights shells."""
     queryset = RightsShell.objects.all()
     template_name = "rights/list.html"
     page_title = "Rights"
 
 
 class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
+    """Create a rights shell."""
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
@@ -66,7 +67,7 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
 
 
 class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
-    '''view a rights shell'''
+    """View a rights shell."""
     model = RightsShell
     template_name = "rights/detail.html"
 
@@ -75,6 +76,7 @@ class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
 
 
 class RightsShellUpdateView(PageTitleMixin, LoginRequiredMixin, UpdateView):
+    """Update a rights shell."""
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -77,9 +77,9 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
-            context['rights_granted'] = RightsGrantedFormSet(self.request.POST, instance=self.object)
+            context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST, instance=self.object)
         else:
-            context['rights_granted'] = RightsGrantedFormSet(instance=self.object)
+            context['rights_granted_form'] = RightsGrantedFormSet(instance=self.object)
         return context
 
     def form_valid(self, form):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -94,7 +94,6 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
             return super().form_invalid(form)
 
 
-
 class GroupingListView(PageTitleMixin, LoginRequiredMixin, ListView):
     """Browse and search groupings."""
     model = Grouping

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -2,7 +2,6 @@ from assign_rights.models import RightsShell, User
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView
 from django.shortcuts import render
-from django.urls import reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -40,7 +39,6 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
-    success_url = None
     page_title = "Create New Rights Shell"
 
     def get_context_data(self, **kwargs):
@@ -61,9 +59,6 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
             return response
         else:
             return super().form_invalid(form)
-
-    def get_success_url(self):
-        return reverse_lazy("rights-detail", kwargs={"pk": self.object.pk})
 
 
 class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -28,13 +28,13 @@ class PageTitleMixin(object):
         return context
 
 
-class RightsShellListView(ListView):
+class RightsShellListView(LoginRequiredMixin, ListView):
     '''browse and search rights shells'''
     queryset = RightsShell.objects.all()
     template_name = "rights/list.html"
 
 
-class RightsShellCreateView(CreateView):
+class RightsShellCreateView(LoginRequiredMixin, CreateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
@@ -69,7 +69,7 @@ class RightsShellDetailView(LoginRequiredMixin, DetailView):
     template_name = "rights/detail.html"
 
 
-class RightsShellUpdateView(UpdateView):
+class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -85,9 +85,9 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
     def form_valid(self, form):
         context = self.get_context_data(form=form)
         rights_granted = context['rights_granted']
-        if rights_granted.is_valid():
+        if rights_granted_form.is_valid():
             response = super().form_valid(form)
-            rights_granted.instance = self.object
+            rights_granted_form.instance = self.object
             rights_granted.save()
             return response
         else:

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -43,14 +43,14 @@ class RightsShellCreateView(LoginRequiredMixin, CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
-            context['rights_granted'] = RightsGrantedFormSet(self.request.POST)
+            context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST)
         else:
-            context['rights_granted'] = RightsGrantedFormSet()
+            context['rights_granted_form'] = RightsGrantedFormSet()
         return context
 
     def form_valid(self, form):
         context = self.get_context_data(form=form)
-        rights_granted = context['rights_granted']
+        rights_granted = context['rights_granted_form']
         if rights_granted.is_valid():
             response = super().form_valid(form)
             rights_granted.instance = self.object
@@ -84,11 +84,11 @@ class RightsShellUpdateView(LoginRequiredMixin, UpdateView):
 
     def form_valid(self, form):
         context = self.get_context_data(form=form)
-        rights_granted = context['rights_granted']
+        rights_granted_form = context['rights_granted_form']
         if rights_granted_form.is_valid():
             response = super().form_valid(form)
             rights_granted_form.instance = self.object
-            rights_granted.save()
+            rights_granted_form.save()
             return response
         else:
             return super().form_invalid(form)


### PR DESCRIPTION
Adds UIs for creating, editing, viewing, and browsing rights statement shells (and associated acts). All fields are available to view and edit; additional validation dependent on rights basis will need to be added. A table was used in the rights shell detail view to show all fields, but that may not be the best way of presenting information.