### PR TITLE
Improves form styling

### DIFF
--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'assign_rights',
+    'crispy_forms',
 ]
 
 MIDDLEWARE = [
@@ -121,3 +122,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 LOGIN_URL = "login"
 LOGIN_REDIRECT_URL = "groupings-list"
+
+# django-crispy-forms template pack
+CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/assign_rights/templates/groupings/manage.html
+++ b/assign_rights/templates/groupings/manage.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
+{% load crispy_forms_tags %}
 
 {% block content %}
 
 <form action="." method="POST" accept-charset="utf-8">
   {% csrf_token %}
-	{{ form.as_p }}
-	<button type="submit">Save</button>
+	{{ form | crispy }}
+	<button class="btn btn-primary" type="submit">Save</button>
 </form>
 
 {% endblock %}

--- a/assign_rights/templates/navbar.html
+++ b/assign_rights/templates/navbar.html
@@ -3,7 +3,7 @@
 <header class="main-header">
 
   <nav class="navbar navbar-expand-sm navbar-dark bg-dark mb-2" role="navigation">
-    <a class="navbar-brand" href="#">Aquila</a>
+    <a class="navbar-brand" href="/">Aquila</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/assign_rights/templates/navbar.html
+++ b/assign_rights/templates/navbar.html
@@ -20,7 +20,7 @@
       </ul>
       <form class="form-inline my-2 my-lg-0">
         {% if request.user.is_authenticated %}
-        <a href="{% url 'logout' %}" class="btn btn-primary my-2 my-sm-0">Logout</a>
+        <a href="{% url 'logout' %}" class="btn btn-secondary my-2 my-sm-0">Logout</a>
         {% endif %}
       </form>
     </div>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -6,8 +6,9 @@
 <form action="." method="POST" accept-charset="utf-8">
 	{% csrf_token %}
 	{{ form | crispy}}
-	{{ rights_granted_form | crispy}}
+	<h2>Rights Granted</h2>
 	{{ rights_granted_form.management_form }}
+	{{ rights_granted_form | crispy}}
 	<button type="submit" class="btn btn-primary">Save</button>
 </form>
 

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
+{% load crispy_forms_tags %}
 
 {% block content %}
 
 <form action="." method="POST" accept-charset="utf-8">
 	{% csrf_token %}
-	{{ form.as_p }}
-	{{ rights_granted_form.as_p }}
+	{{ form | crispy}}
+	{{ rights_granted_form | crispy}}
 	{{ rights_granted_form.management_form }}
 	<button type="submit" class="btn btn-primary">Save</button>
 </form>

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -31,7 +31,7 @@ class RightsShellListView(PageTitleMixin, LoginRequiredMixin, ListView):
     """Browse and search rights shells."""
     model = RightsShell
     template_name = "rights/list.html"
-    page_title = "Rights"
+    page_title = "Rights Shells"
 
 
 class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 clinner==1.12.3
 colorlog==3.2.0
 Django==2.2.13
+django-crispy-forms==1.9.2
 djangorestframework==3.11.0
 gitdb==4.0.5
 GitPython==3.1.3


### PR DESCRIPTION
Adds `django-crispy-forms` for quick and dirty form styling. Does not address custom validation, etc. Fixes #31 