### PR TITLE
Show specific fields on rights form depending on basis

### DIFF
--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -27,6 +27,29 @@ class RightsShellForm(ModelForm):
         ]
 
 
+class BasisForm(ModelForm):
+    class Meta:
+        model = RightsShell
+        fields = [
+            'rights_basis',
+        ]
+
+
+class CopyrightForm(ModelForm):
+    class Meta:
+        model = RightsShell
+        fields = [
+            'copyright_status',
+            'determination_date',
+            'note',
+            'start_date',
+            'end_date',
+            'start_date_period',
+            'end_date_period',
+            'end_date_open',
+        ]
+
+
 class RightsGrantedForm(ModelForm):
     class Meta:
         model = RightsGranted

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, inlineformset_factory
+from django.forms import ModelForm, Select, inlineformset_factory
 
 from .models import Grouping, RightsGranted, RightsShell
 
@@ -25,6 +25,7 @@ class RightsShellForm(ModelForm):
             'license_terms',
             'statute_citation'
         ]
+        widgets = {'rights_basis': Select(attrs={'v-model': 'selected'})}
 
 
 class RightsGrantedForm(ModelForm):

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,5 +1,5 @@
 from django.forms import (DateInput, ModelForm, NumberInput, Select, Textarea,
-                          inlineformset_factory)
+                          TextInput, inlineformset_factory)
 
 from .models import Grouping, RightsGranted, RightsShell
 
@@ -16,6 +16,7 @@ class RightsShellForm(ModelForm):
         fields = [
             'rights_basis',
             'copyright_status',
+            'jurisdiction',
             'determination_date',
             'note',
             'start_date',
@@ -29,6 +30,7 @@ class RightsShellForm(ModelForm):
         widgets = {
             'rights_basis': Select(attrs={'v-model': 'selected', }),
             'copyright_status': Select(attrs={}),
+            'jurisdiction': TextInput(attrs={'maxlength': '2'}),
             'determination_date': DateInput(attrs={}),
             'note': Textarea(attrs={}),
             'start_date': DateInput(attrs={}),
@@ -37,6 +39,46 @@ class RightsShellForm(ModelForm):
             'end_date_period': NumberInput(attrs={}),
             'license_terms': Textarea(attrs={}),
             'statute_citation': Textarea(attrs={})}
+
+
+class CopyrightForm(RightsShellForm):
+    class Meta(RightsShellForm.Meta):
+        exclude = (
+            'rights_basis',
+            'license_terms',
+            'statute_citation'
+        )
+
+
+class OtherForm(RightsShellForm):
+    class Meta(RightsShellForm.Meta):
+        exclude = (
+            'rights_basis',
+            'copyright_status',
+            'jurisdiction',
+            'license_terms',
+            'statute_citation'
+        )
+
+
+class LicenseForm(RightsShellForm):
+    class Meta(RightsShellForm.Meta):
+        exclude = (
+            'rights_basis',
+            'copyright_status',
+            'jurisdiction',
+            'statute_citation'
+        )
+
+
+class StatuteForm(RightsShellForm):
+    class Meta(RightsShellForm.Meta):
+        exclude = (
+            'rights_basis',
+            'copyright_status',
+            'jurisdiction',
+            'license_terms',
+        )
 
 
 class RightsGrantedForm(ModelForm):

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -27,29 +27,6 @@ class RightsShellForm(ModelForm):
         ]
 
 
-class BasisForm(ModelForm):
-    class Meta:
-        model = RightsShell
-        fields = [
-            'rights_basis',
-        ]
-
-
-class CopyrightForm(ModelForm):
-    class Meta:
-        model = RightsShell
-        fields = [
-            'copyright_status',
-            'determination_date',
-            'note',
-            'start_date',
-            'end_date',
-            'start_date_period',
-            'end_date_period',
-            'end_date_open',
-        ]
-
-
 class RightsGrantedForm(ModelForm):
     class Meta:
         model = RightsGranted

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -27,17 +27,16 @@ class RightsShellForm(ModelForm):
             'statute_citation'
         ]
         widgets = {
-            'rights_basis': Select(attrs={'v-model': 'selected', 'class': 'form-control'}),
-            'copyright_status': Select(attrs={'class': 'form-control'}),
-            'determination_date': DateInput(attrs={'class': 'form-control'}),
-            'note': Textarea(attrs={'class': 'form-control'}),
-            'start_date': DateInput(attrs={'class': 'form-control'}),
-            'end_date': DateInput(attrs={'class': 'form-control'}),
-            'start_date_period': NumberInput(attrs={'class': 'form-control'}),
-            'end_date_period': NumberInput(attrs={'class': 'form-control'}),
-            'license_terms': Textarea(attrs={'class': 'form-control'}),
-            'statute_citation': Textarea(attrs={'class': 'form-control'})
-        }
+            'rights_basis': Select(attrs={'v-model': 'selected', }),
+            'copyright_status': Select(attrs={}),
+            'determination_date': DateInput(attrs={}),
+            'note': Textarea(attrs={}),
+            'start_date': DateInput(attrs={}),
+            'end_date': DateInput(attrs={}),
+            'start_date_period': NumberInput(attrs={}),
+            'end_date_period': NumberInput(attrs={}),
+            'license_terms': Textarea(attrs={}),
+            'statute_citation': Textarea(attrs={})}
 
 
 class RightsGrantedForm(ModelForm):

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,4 +1,5 @@
-from django.forms import ModelForm, Select, inlineformset_factory
+from django.forms import (DateInput, ModelForm, NumberInput, Select, Textarea,
+                          inlineformset_factory)
 
 from .models import Grouping, RightsGranted, RightsShell
 
@@ -25,7 +26,18 @@ class RightsShellForm(ModelForm):
             'license_terms',
             'statute_citation'
         ]
-        widgets = {'rights_basis': Select(attrs={'v-model': 'selected'})}
+        widgets = {
+            'rights_basis': Select(attrs={'v-model': 'selected', 'class': 'form-control'}),
+            'copyright_status': Select(attrs={'class': 'form-control'}),
+            'determination_date': DateInput(attrs={'class': 'form-control'}),
+            'note': Textarea(attrs={'class': 'form-control'}),
+            'start_date': DateInput(attrs={'class': 'form-control'}),
+            'end_date': DateInput(attrs={'class': 'form-control'}),
+            'start_date_period': NumberInput(attrs={'class': 'form-control'}),
+            'end_date_period': NumberInput(attrs={'class': 'form-control'}),
+            'license_terms': Textarea(attrs={'class': 'form-control'}),
+            'statute_citation': Textarea(attrs={'class': 'form-control'})
+        }
 
 
 class RightsGrantedForm(ModelForm):

--- a/assign_rights/templates/base.html
+++ b/assign_rights/templates/base.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
     {% include 'head.html' %}
     {% block extra_css %}{% endblock %}
   </head>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -16,8 +16,8 @@
         <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
         <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
         <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_rights_basis_period">Rights Basis Period</label>{{ form.rights_basis_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">End Date Open</label>{{ form.end_date_open }}</div>
+        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==statute">
         <div class="form-group"><label for="id_statute_citation">Statute Citation</label>{{ form.statute_citation }}</div>
@@ -25,26 +25,26 @@
         <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
         <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
         <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
+        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==license">
         <div class="form-group"><label for="id_license_terms">License Terms</label>{{ form.license_terms }}</div>
         <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
         <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
         <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
+        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==other">
         <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
         <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
         <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
+        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
     </div>
     <h2>Rights Granted</h2>
 

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -9,44 +9,18 @@
 		{{ form.rights_basis | as_crispy_field }}
 	</div>
     <div v-if="selected==copyright">
-        <div>{{ form.copyright_status | as_crispy_field }}</div>
-        <div>{{ form.determination_date | as_crispy_field }}</div>
-        <div>{{ form.note | as_crispy_field }}</div>
-        <div>{{ form.start_date | as_crispy_field }}</div>
-        <div>{{ form.end_date | as_crispy_field }}</div>
-        <div>{{ form.start_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_open | as_crispy_field }}</div>
+        <div>{{ copyright_form | crispy }}</div>
     </div>
     <div v-if="selected==statute">
-        <div>{{ form.statute_citation | as_crispy_field }}</div>
-        <div>{{ form.determination_date | as_crispy_field }}</div>
-        <div>{{ form.note | as_crispy_field }}</div>
-        <div>{{ form.start_date | as_crispy_field }}</div>
-        <div>{{ form.end_date | as_crispy_field }}</div>
-        <div>{{ form.start_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_open | as_crispy_field }}</div>
+        <div>{{ statute_form | crispy }}</div>
     </div>
     <div v-if="selected==license">
-        <div>{{ form.license_terms | as_crispy_field }}</div>
-        <div>{{ form.note | as_crispy_field }}</div>
-        <div>{{ form.start_date | as_crispy_field }}</div>
-        <div>{{ form.end_date | as_crispy_field }}</div>
-        <div>{{ form.start_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_open | as_crispy_field }}</div>
+        <div>{{ license_form | crispy }}</div>
     </div>
     <div v-if="selected==other">
-        <div>{{ form.note | as_crispy_field }}</div>
-        <div>{{ form.start_date | as_crispy_field }}</div>
-        <div>{{ form.end_date | as_crispy_field }}</div>
-        <div>{{ form.start_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_period | as_crispy_field }}</div>
-        <div>{{ form.end_date_open | as_crispy_field }}</div>
+        <div>{{ other_form | crispy }}</div>
     </div>
     <h2>Rights Granted</h2>
-
     {{ rights_granted_form.management_form }}
     {{ rights_granted_form | crispy}}
     <button type="submit" class="btn btn-primary">Save</button>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -6,9 +6,6 @@
 <form class="mb-3" action="." method="POST" accept-charset="utf-8">
     {% csrf_token %}
     {{ form | crispy}}
-    <div>
-    {{ copyright_form | crispy}}
-</div>
     <h2>Rights Granted</h2>
     {{ rights_granted_form.management_form }}
     {{ rights_granted_form | crispy}}

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -3,18 +3,33 @@
 
 {% block content %}
 
-<form class="mb-3" action="." method="POST" accept-charset="utf-8">
+<form class="mb-3" action="." method="POST" accept-charset="utf-8" id="vue-form">
     {% csrf_token %}
-    {{ form | crispy}}
+	{{ form.rights_basis }}
+	<div v-if="selected==copyright">
+		<p>{{ form.copyright_status }}</p>
+		<p>{{ form.determination_date }}</p>
+		<p>{{ form.note }}</p>
+		<p>{{ form.start_date }}</p>
+		<p>{{ form.end_date }}</p>
+		<p>{{ form.start_date_period }}</p>
+		<p>{{ form.rights_basis_period }}</p>
+		<p>{{ form.end_date_open }}</p>
+	</div>
+    {# {{ form | crispy}} #}
     <h2>Rights Granted</h2>
+
     {{ rights_granted_form.management_form }}
     {{ rights_granted_form | crispy}}
     <button type="submit" class="btn btn-primary">Save</button>
 </form>
-    <script>
-        var data = {
-            basis: "copyright"
-        }
-
-    </script>
+<script type="text/javascript">
+  let app = new Vue({
+    el: "#vue-form",
+    data: {
+      selected: '',
+		copyright: 'Copyright',
+    },
+  });
+</script>
 {% endblock %}

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -5,46 +5,45 @@
 
 <form class="mb-3" action="." method="POST" accept-charset="utf-8" id="vue-form">
     {% csrf_token %}
-    <div class="form-group">
-		<label for="id_rights_basis">Rights Basis</label>
-		{{ form.rights_basis }}
+    <div>
+		{{ form.rights_basis | as_crispy_field }}
 	</div>
     <div v-if="selected==copyright">
-        <div class="form-group"><label for="id_copyright_status">Copyright Status</label>{{ form.copyright_status }}</div>
-        <div class="form-group"><label for="id_determination_date">Determination Date</label>{{ form.determination_date }}</div>
-        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
-        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
-        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
+        <div>{{ form.copyright_status | as_crispy_field }}</div>
+        <div>{{ form.determination_date | as_crispy_field }}</div>
+        <div>{{ form.note | as_crispy_field }}</div>
+        <div>{{ form.start_date | as_crispy_field }}</div>
+        <div>{{ form.end_date | as_crispy_field }}</div>
+        <div>{{ form.start_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_open | as_crispy_field }}</div>
     </div>
     <div v-if="selected==statute">
-        <div class="form-group"><label for="id_statute_citation">Statute Citation</label>{{ form.statute_citation }}</div>
-        <div class="form-group"><label for="id_determination_date">Determination Date</label>{{ form.determination_date }}</div>
-        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
-        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
-        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
+        <div>{{ form.statute_citation | as_crispy_field }}</div>
+        <div>{{ form.determination_date | as_crispy_field }}</div>
+        <div>{{ form.note | as_crispy_field }}</div>
+        <div>{{ form.start_date | as_crispy_field }}</div>
+        <div>{{ form.end_date | as_crispy_field }}</div>
+        <div>{{ form.start_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_open | as_crispy_field }}</div>
     </div>
     <div v-if="selected==license">
-        <div class="form-group"><label for="id_license_terms">License Terms</label>{{ form.license_terms }}</div>
-        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
-        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
-        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
+        <div>{{ form.license_terms | as_crispy_field }}</div>
+        <div>{{ form.note | as_crispy_field }}</div>
+        <div>{{ form.start_date | as_crispy_field }}</div>
+        <div>{{ form.end_date | as_crispy_field }}</div>
+        <div>{{ form.start_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_open | as_crispy_field }}</div>
     </div>
     <div v-if="selected==other">
-        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
-        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
-        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
-        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_period">End Date Period</label>{{ form.end_date_period }}</div>
-        <div class="form-group"><label for="id_end_date_open">Open End Date</label>{{ form.end_date_open }}</div>
+        <div>{{ form.note | as_crispy_field }}</div>
+        <div>{{ form.start_date | as_crispy_field }}</div>
+        <div>{{ form.end_date | as_crispy_field }}</div>
+        <div>{{ form.start_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_period | as_crispy_field }}</div>
+        <div>{{ form.end_date_open | as_crispy_field }}</div>
     </div>
     <h2>Rights Granted</h2>
 

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -5,43 +5,46 @@
 
 <form class="mb-3" action="." method="POST" accept-charset="utf-8" id="vue-form">
     {% csrf_token %}
-    {{ form.rights_basis }}
+    <div class="form-group">
+		<label for="id_rights_basis">Rights Basis</label>
+		{{ form.rights_basis }}
+	</div>
     <div v-if="selected==copyright">
-        <p>{{ form.copyright_status }}</p>
-        <p>{{ form.determination_date }}</p>
-        <p>{{ form.note }}</p>
-        <p>{{ form.start_date }}</p>
-        <p>{{ form.end_date }}</p>
-        <p>{{ form.start_date_period }}</p>
-        <p>{{ form.rights_basis_period }}</p>
-        <p>{{ form.end_date_open }}</p>
+        <div class="form-group"><label for="id_copyright_status">Copyright Status</label>{{ form.copyright_status }}</div>
+        <div class="form-group"><label for="id_determination_date">Determination Date</label>{{ form.determination_date }}</div>
+        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
+        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
+        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
+        <div class="form-group"><label for="id_start_date_period">Start Date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_rights_basis_period">Rights Basis Period</label>{{ form.rights_basis_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">End Date Open</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==statute">
-        <p>{{ form.statute_citation }}</p>
-        <p>{{ form.determination_date }}</p>
-        <p>{{ form.note }}</p>
-        <p>{{ form.start_date }}</p>
-        <p>{{ form.end_date }}</p>
-        <p>{{ form.start_date_period }}</p>
-        <p>{{ form.rights_basis_period }}</p>
-        <p>{{ form.end_date_open }}</p>
+        <div class="form-group"><label for="id_statute_citation">Statute Citation</label>{{ form.statute_citation }}</div>
+        <div class="form-group"><label for="id_determination_date">Determination Date</label>{{ form.determination_date }}</div>
+        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
+        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
+        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
+        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==license">
-        <p>{{ form.license_terms }}</p>
-        <p>{{ form.note }}</p>
-        <p>{{ form.start_date }}</p>
-        <p>{{ form.end_date }}</p>
-        <p>{{ form.start_date_period }}</p>
-        <p>{{ form.rights_basis_period }}</p>
-        <p>{{ form.end_date_open }}</p>
+        <div class="form-group"><label for="id_license_terms">License Terms</label>{{ form.license_terms }}</div>
+        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
+        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
+        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
+        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
     </div>
     <div v-if="selected==other">
-        <p>{{ form.note }}</p>
-        <p>{{ form.start_date }}</p>
-        <p>{{ form.end_date }}</p>
-        <p>{{ form.start_date_period }}</p>
-        <p>{{ form.rights_basis_period }}</p>
-        <p>{{ form.end_date_open }}</p>
+        <div class="form-group"><label for="id_note">Note</label>{{ form.note }}</div>
+        <div class="form-group"><label for="id_start_date">Start Date</label>{{ form.start_date }}</div>
+        <div class="form-group"><label for="id_end_date">End Date</label>{{ form.end_date }}</div>
+        <div class="form-group"><label for="id_start_date_period">start_date Period</label>{{ form.start_date_period }}</div>
+        <div class="form-group"><label for="id_rights_basis_period">rights_basis Period</label>{{ form.rights_basis_period }}</div>
+        <div class="form-group"><label for="id_end_date_open">end_date Open</label>{{ form.end_date_open }}</div>
     </div>
     <h2>Rights Granted</h2>
 

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -5,18 +5,44 @@
 
 <form class="mb-3" action="." method="POST" accept-charset="utf-8" id="vue-form">
     {% csrf_token %}
-	{{ form.rights_basis }}
-	<div v-if="selected==copyright">
-		<p>{{ form.copyright_status }}</p>
-		<p>{{ form.determination_date }}</p>
-		<p>{{ form.note }}</p>
-		<p>{{ form.start_date }}</p>
-		<p>{{ form.end_date }}</p>
-		<p>{{ form.start_date_period }}</p>
-		<p>{{ form.rights_basis_period }}</p>
-		<p>{{ form.end_date_open }}</p>
-	</div>
-    {# {{ form | crispy}} #}
+    {{ form.rights_basis }}
+    <div v-if="selected==copyright">
+        <p>{{ form.copyright_status }}</p>
+        <p>{{ form.determination_date }}</p>
+        <p>{{ form.note }}</p>
+        <p>{{ form.start_date }}</p>
+        <p>{{ form.end_date }}</p>
+        <p>{{ form.start_date_period }}</p>
+        <p>{{ form.rights_basis_period }}</p>
+        <p>{{ form.end_date_open }}</p>
+    </div>
+    <div v-if="selected==statute">
+        <p>{{ form.statute_citation }}</p>
+        <p>{{ form.determination_date }}</p>
+        <p>{{ form.note }}</p>
+        <p>{{ form.start_date }}</p>
+        <p>{{ form.end_date }}</p>
+        <p>{{ form.start_date_period }}</p>
+        <p>{{ form.rights_basis_period }}</p>
+        <p>{{ form.end_date_open }}</p>
+    </div>
+    <div v-if="selected==license">
+        <p>{{ form.license_terms }}</p>
+        <p>{{ form.note }}</p>
+        <p>{{ form.start_date }}</p>
+        <p>{{ form.end_date }}</p>
+        <p>{{ form.start_date_period }}</p>
+        <p>{{ form.rights_basis_period }}</p>
+        <p>{{ form.end_date_open }}</p>
+    </div>
+    <div v-if="selected==other">
+        <p>{{ form.note }}</p>
+        <p>{{ form.start_date }}</p>
+        <p>{{ form.end_date }}</p>
+        <p>{{ form.start_date_period }}</p>
+        <p>{{ form.rights_basis_period }}</p>
+        <p>{{ form.end_date_open }}</p>
+    </div>
     <h2>Rights Granted</h2>
 
     {{ rights_granted_form.management_form }}
@@ -28,7 +54,10 @@
     el: "#vue-form",
     data: {
       selected: '',
-		copyright: 'Copyright',
+        copyright: 'Copyright',
+        statute: 'Statute',
+        license: 'License',
+        other: 'Other',
     },
   });
 </script>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -4,12 +4,20 @@
 {% block content %}
 
 <form class="mb-3" action="." method="POST" accept-charset="utf-8">
-	{% csrf_token %}
-	{{ form | crispy}}
-	<h2>Rights Granted</h2>
-	{{ rights_granted_form.management_form }}
-	{{ rights_granted_form | crispy}}
-	<button type="submit" class="btn btn-primary">Save</button>
+    {% csrf_token %}
+    {{ form | crispy}}
+    <div>
+    {{ copyright_form | crispy}}
+</div>
+    <h2>Rights Granted</h2>
+    {{ rights_granted_form.management_form }}
+    {{ rights_granted_form | crispy}}
+    <button type="submit" class="btn btn-primary">Save</button>
 </form>
+    <script>
+        var data = {
+            basis: "copyright"
+        }
 
+    </script>
 {% endblock %}

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -6,8 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .assemble import RightsAssembler
-from .forms import (BasisForm, CopyrightForm, GroupingForm,
-                    RightsGrantedFormSet, RightsShellForm)
+from .forms import GroupingForm, RightsGrantedFormSet, RightsShellForm
 from .models import Grouping
 
 
@@ -38,16 +37,14 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
     """Create a rights shell."""
     model = RightsShell
     template_name = "rights/manage.html"
-    form_class = BasisForm
+    form_class = RightsShellForm
     page_title = "Create New Rights Shell"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
-            context['copyright_form'] = CopyrightForm(self.request.POST)
             context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST)
         else:
-            context['copyright_form'] = CopyrightForm(self.request.POST)
             context['rights_granted_form'] = RightsGrantedFormSet()
         return context
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -6,7 +6,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .assemble import RightsAssembler
-from .forms import GroupingForm, RightsGrantedFormSet, RightsShellForm
+from .forms import (BasisForm, CopyrightForm, GroupingForm,
+                    RightsGrantedFormSet, RightsShellForm)
 from .models import Grouping
 
 
@@ -37,14 +38,16 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
     """Create a rights shell."""
     model = RightsShell
     template_name = "rights/manage.html"
-    form_class = RightsShellForm
+    form_class = BasisForm
     page_title = "Create New Rights Shell"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
+            context['copyright_form'] = CopyrightForm(self.request.POST)
             context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST)
         else:
+            context['copyright_form'] = CopyrightForm(self.request.POST)
             context['rights_granted_form'] = RightsGrantedFormSet()
         return context
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -6,7 +6,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .assemble import RightsAssembler
-from .forms import GroupingForm, RightsGrantedFormSet, RightsShellForm
+from .forms import (CopyrightForm, GroupingForm, LicenseForm, OtherForm,
+                    RightsGrantedFormSet, RightsShellForm, StatuteForm)
 from .models import Grouping
 
 
@@ -44,8 +45,16 @@ class RightsShellCreateView(PageTitleMixin, LoginRequiredMixin, CreateView):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
             context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST)
+            context['copyright_form'] = CopyrightForm(self.request.POST)
+            context['other_form'] = OtherForm(self.request.POST)
+            context['statute_form'] = StatuteForm(self.request.POST)
+            context['license_form'] = LicenseForm(self.request.POST)
         else:
             context['rights_granted_form'] = RightsGrantedFormSet()
+            context['copyright_form'] = CopyrightForm()
+            context['other_form'] = OtherForm()
+            context['statute_form'] = StatuteForm()
+            context['license_form'] = LicenseForm()
         return context
 
     def form_valid(self, form):


### PR DESCRIPTION
This is very much a work in progress, but I'm getting stuck with both django-crispy-forms and Javascript/Vue.js.

I've been using these resources:

- Dynamic forms with Django and Vue.js https://medium.com/swlh/building-dynamic-forms-with-django-formsets-and-vue-js-f3c6e2dddd4a#81c0
- Vue.js in a Django template https://vsupalov.com/vue-js-in-django-template/
- Django crispy forms https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html

I've done the following so far:

- In forms.py, I added a form for the basis field only and a form for copyright specific fields (if this is the right approach, the plan is to add forms for each of the bases). I'm not sure if these should be forms or formsets, or if there's another way of handling these. My idea was that the basis would always be rendered, and the other forms would be conditionally rendered.
- In views.py, I added references to both forms that I added.
- In base.html I added a line to include vue.js 
- In manage.html, I rendered the new forms and added a placeholder area for vue.js code

I think what I want to do is:
- Add a vue data binding to the rights basis field
- Depending on the user input to the rights basis field, render one of the basis-specific forms

I'm struggling with (at least) the following two things:
- Adding an attribute to a field in a crispy form
- Writing the Vue.js script to refer to that variable and then do something with it