### PR TITLE
Debugs issues with formsets

### DIFF
--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -107,5 +107,5 @@ RightsGrantedFormSet = inlineformset_factory(
     RightsGranted,
     extra=0,
     form=RightsGrantedForm,
-    can_delete=False
+    can_delete=True
 )

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -14,13 +14,13 @@
 <dl class="row">
   <dt class="col-sm-2">Basis</dt>
   <dd class="col-sm-10">{{ rightsshell.rights_basis }}</dd>
-  {% if rightshell.rights_basis == Copyright %}
+  {% if rightsshell.get_rights_basis_display == "Copyright" %}
   <dt class="col-sm-2">Copyright Status</dt>
   <dd class="col-sm-10">{{ rightsshell.copyright_status }}</dd>
-  {% elif rightshell.rights_basis == License %}
+  {% elif rightsshell.get_rights_basis_display == "License" %}
   <dt class="col-sm-2">License Terms</dt>
   <dd class="col-sm-10">{{ rightsshell.license_terms }}</dd>
-  {% elif rightshell.rights_basis == Statute %}
+  {% elif rightsshell.get_rights_basis_display == "Statute" %}
   <dt class="col-sm-2">Statute Citation</dt>
   <dd class="col-sm-10">{{ rightsshell.statute_citation }}</dd>
   {% endif %}

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -31,7 +31,7 @@
            v-model="getInitialRightsGrantedForms()">
 
     <div v-for="(rights_granted, rights_granted_index) in rights_basis.rights_granted"
-          v-show="rights_granted.marked_for_delete !== true">
+         v-show="rights_granted.marked_for_delete !== true">
 
       <span v-if="rights_granted.id">
         <input type="hidden"
@@ -61,7 +61,8 @@
                       v-model="rights_granted.act"
                       v-bind:id="'id_rightsgranted_set-'+rights_granted.rights_granted_formset_index+'-act'"
                       class="form-control">
-                {% for value, text in rights_granted_form.forms.0.act.field.choices %}
+                <option value="">-------</option>
+                {% for value, text in act_choices %}
                 <option value={{value}}>{{text}}</option>
                 {% endfor %}
               </select>
@@ -72,9 +73,10 @@
                       v-model="rights_granted.restriction"
                       v-bind:id="'id_rightsgranted_set-'+rights_granted.rights_granted_formset_index+'-restriction'"
                       class="form-control">
-                      {% for value, text in rights_granted_form.forms.0.restriction.field.choices %}
-                      <option value={{value}}>{{text}}</option>
-                      {% endfor %}
+                <option value="">-------</option>
+                {% for value, text in restriction_choices %}
+                <option value={{value}}>{{text}}</option>
+                {% endfor %}
               </select>
             </div>
           </div>
@@ -152,11 +154,7 @@
       {% if rights_granted_form %}
         {% for nested_form in rights_granted_form %}
           {
-            id:  {% if not nested_form.id.value %}
-                null
-            {% else %}
-                {{ nested_form.id.value }}
-            {% endif %},
+            id:  {% if not nested_form.id.value %}null{% else %}{{ nested_form.id.value }}{% endif %},
             rights_granted_formset_index: {{ forloop.counter0 }},
             marked_for_delete: false,
             act: '{{ nested_form.act.value|default_if_none:"" }}',
@@ -201,16 +199,16 @@
       addNewRightsGranted: function (event) {
         event.preventDefault();
         const default_new_rights_granted = {
-            book_formset_index: this.getTotalRightsGrantedForms(),
+          rights_granted_formset_index: this.getTotalRightsGrantedForms(),
         };
         this.$data.rights_basis.rights_granted.push(default_new_rights_granted);
       },
       removeRightsGranted: function (event, rights_granted_index) {
         event.preventDefault();
         if (this.$data.rights_basis.rights_granted[rights_granted_index].id) {
-            Vue.set(this.rights_basis.rights_granted[rights_granted_index], 'marked_for_delete', true);
+          Vue.set(this.$data.rights_basis.rights_granted[rights_granted_index], 'marked_for_delete', true);
         } else {
-            this.$data.rights_basis.rights_granted.splice(rights_granted_index, 1)
+          this.$data.rights_basis.rights_granted.splice(rights_granted_index, 1)
         }
       },
     }

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,5 +1,3 @@
-from assign_rights.mixins.authmixins import EditMixin
-from assign_rights.models import RightsShell
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
@@ -10,7 +8,8 @@ from .assemble import RightsAssembler
 from .forms import (CopyrightForm, GroupingForm, LicenseForm, OtherForm,
                     RightsGrantedFormSet, RightsShellForm,
                     RightsShellUpdateForm, StatuteForm)
-from .models import Grouping
+from .mixins.authmixins import EditMixin
+from .models import Grouping, RightsGranted, RightsShell
 
 
 class PageTitleMixin(object):
@@ -46,6 +45,8 @@ class RightsShellCreateView(PageTitleMixin, EditMixin, CreateView):
     def get_context_data(self, **kwargs):
         """Load specific rights basis form based on logic in rights create template. Returns subclass of RightsShellForm"""
         context = super().get_context_data(**kwargs)
+        context["act_choices"] = RightsGranted.ACT_CHOICES
+        context["restriction_choices"] = RightsGranted.RESTRICTION_CHOICES
         if self.request.POST:
             context['rights_granted_form'] = RightsGrantedFormSet(self.request.POST)
             context['copyright_form'] = CopyrightForm(self.request.POST)
@@ -87,6 +88,8 @@ class RightsShellUpdateView(PageTitleMixin, EditMixin, UpdateView):
         """Loads main rights basis form as well as inline formsets for rights granted or restricted."""
         context = super().get_context_data(**kwargs)
         form_cls = self.get_form_cls(context["object"].rights_basis)
+        context["act_choices"] = RightsGranted.ACT_CHOICES
+        context["restriction_choices"] = RightsGranted.RESTRICTION_CHOICES
         if self.request.POST:
             context["rights_granted_form"] = RightsGrantedFormSet(self.request.POST, instance=self.object)
             context["basis_form"] = form_cls(self.request.POST, instance=self.object)


### PR DESCRIPTION
I started out to address #85, but this turned into a bit of a journey. So, there are actually a couple of things this PR does.
1. allow deletion of formset instances (by flipping the boolean `can_delete`)
2. debug an error in the `addNewRightsGranted` function which was preventing formset indexes from being correctly calculated
3. Added `act` and `restriction` choices into the view so we can access those in the template. Previously I was pulling those from the first form in the formset, but because we've now set the `extra` parameter to `0` there are no forms in the formset. This solution feels a little kludgy, but it will work for now. fixes #85 
4. Debug some conditionals in the Rights Shell detail template.