### PR TITLE
Allow users to delete Groupings and RightsShells

### DIFF
--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -17,8 +17,8 @@ from assign_rights.views import (AquilaLoginView, GroupingCreateView,
                                  GroupingDeleteView, GroupingDetailView,
                                  GroupingListView, GroupingUpdateView,
                                  RightsAssemblerView, RightsShellCreateView,
-                                 RightsShellDetailView, RightsShellListView,
-                                 RightsShellUpdateView)
+                                 RightsShellDeleteView, RightsShellDetailView,
+                                 RightsShellListView, RightsShellUpdateView)
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
@@ -37,5 +37,6 @@ urlpatterns = [
     path('rights/', RightsShellListView.as_view(), name='rights-list'),
     path('rights/create/', RightsShellCreateView.as_view(), name='rights-create'),
     path('rights/<int:pk>/update/', RightsShellUpdateView.as_view(), name='rights-update'),
+    path('rights/<int:pk>/delete/', RightsShellDeleteView.as_view(), name='rights-delete'),
     path('rights/<int:pk>/', RightsShellDetailView.as_view(), name='rights-detail'),
 ]

--- a/aquila/urls.py
+++ b/aquila/urls.py
@@ -14,10 +14,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from assign_rights.views import (AquilaLoginView, GroupingCreateView,
-                                 GroupingDetailView, GroupingListView,
-                                 GroupingUpdateView, RightsAssemblerView,
-                                 RightsShellCreateView, RightsShellDetailView,
-                                 RightsShellListView, RightsShellUpdateView)
+                                 GroupingDeleteView, GroupingDetailView,
+                                 GroupingListView, GroupingUpdateView,
+                                 RightsAssemblerView, RightsShellCreateView,
+                                 RightsShellDetailView, RightsShellListView,
+                                 RightsShellUpdateView)
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
@@ -29,6 +30,7 @@ urlpatterns = [
     path('groupings/<int:pk>/', GroupingDetailView.as_view(), name="groupings-detail"),
     path('groupings/create/', GroupingCreateView.as_view(), name="groupings-create"),
     path('groupings/<int:pk>/update/', GroupingUpdateView.as_view(), name="groupings-update"),
+    path('groupings/<int:pk>/delete/', GroupingDeleteView.as_view(), name="groupings-delete"),
     path('oauth2/', include('django_auth_adfs.urls')),
     path('login/', AquilaLoginView.as_view(template_name="users/login.html"), name="login"),
     path('logout/', LogoutView.as_view(next_page="/login"), name="logout"),

--- a/assign_rights/models.py
+++ b/assign_rights/models.py
@@ -84,6 +84,9 @@ class Grouping(models.Model):
     def get_absolute_url(self):
         return reverse("groupings-detail", kwargs={"pk": self.pk})
 
+    def __str__(self):
+        return self.title
+
 
 class User(AbstractUser):
     pass

--- a/assign_rights/templates/groupings/confirm_delete.html
+++ b/assign_rights/templates/groupings/confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<form method="post">
+  {% csrf_token %}
+  <p >Are you sure you want to delete {{ object }}?</p>
+  <input class="btn btn-danger" type="submit" value="Confirm">
+  <a class="btn btn-secondary" href={% url 'groupings-detail' pk=object.pk %}>Cancel</a>
+</form>
+
+{% endblock %}

--- a/assign_rights/templates/groupings/detail.html
+++ b/assign_rights/templates/groupings/detail.html
@@ -16,4 +16,7 @@
 {% if request.user|has_group:"edit" %}
 <a class="btn btn-warning" href="{% url 'groupings-update' pk=object.pk %}">Edit</a>
 {% endif %}
+{% if request.user|has_group:"delete" %}
+<a class="btn btn-danger" href="{% url 'groupings-delete' pk=object.pk %}">Delete</a>
+{% endif %}
 {% endblock %}

--- a/assign_rights/templates/rights/confirm_delete.html
+++ b/assign_rights/templates/rights/confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<form method="post">
+  {% csrf_token %}
+  <p >Are you sure you want to delete {{ object }}?</p>
+  <input class="btn btn-danger" type="submit" value="Confirm">
+  <a class="btn btn-secondary" href={% url 'rights-detail' pk=object.pk %}>Cancel</a>
+</form>
+
+{% endblock %}

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -89,5 +89,8 @@
 {% if request.user|has_group:"edit" %}
 <a class="btn btn-warning" href="{% url 'rights-update' pk=object.pk %}">Edit</a>
 {% endif %}
+{% if request.user|has_group:"delete" %}
+<a class="btn btn-danger" href="{% url 'rights-delete' pk=object.pk %}">Delete</a>
+{% endif %}
 
 {% endblock %}

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -123,6 +123,14 @@ class RightsShellUpdateView(PageTitleMixin, EditMixin, UpdateView):
         return "Update Rights Shell {}".format(context["object"].pk)
 
 
+class RightsShellDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
+    """Delete a rights shell."""
+    model = RightsShell
+    template_name = "rights/confirm_delete.html"
+    page_title = "Confirm Delete"
+    success_url = reverse_lazy("rights-list")
+
+
 class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
     """View a rights shell."""
     model = RightsShell
@@ -147,6 +155,14 @@ class GroupingCreateView(PageTitleMixin, EditMixin, CreateView):
     page_title = "Create New Grouping"
 
 
+class GroupingDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
+    """Delete a grouping"""
+    model = Grouping
+    success_url = reverse_lazy("groupings-list")
+    template_name = "groupings/confirm_delete.html"
+    page_title = "Confirm Delete"
+
+
 class GroupingDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
     """View a grouping."""
     model = Grouping
@@ -164,13 +180,6 @@ class GroupingUpdateView(PageTitleMixin, EditMixin, UpdateView):
 
     def get_page_title(self, context):
         return "Update {}".format(context["object"].title)
-
-
-class GroupingDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
-    model = Grouping
-    success_url = reverse_lazy("groupings-list")
-    template_name = "groupings/confirm_delete.html"
-    page_title = "Confirm Delete"
 
 
 class AquilaLoginView(PageTitleMixin, LoginView):

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -1,8 +1,8 @@
-from assign_rights.mixins.authmixins import EditMixin
-from assign_rights.models import RightsShell
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView
-from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from django.urls import reverse_lazy
+from django.views.generic import (CreateView, DeleteView, DetailView, ListView,
+                                  UpdateView)
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -10,7 +10,8 @@ from .assemble import RightsAssembler
 from .forms import (CopyrightForm, GroupingForm, LicenseForm, OtherForm,
                     RightsGrantedFormSet, RightsShellForm,
                     RightsShellUpdateForm, StatuteForm)
-from .models import Grouping
+from .mixins.authmixins import DeleteMixin, EditMixin
+from .models import Grouping, RightsShell
 
 
 class PageTitleMixin(object):
@@ -163,6 +164,13 @@ class GroupingUpdateView(PageTitleMixin, EditMixin, UpdateView):
 
     def get_page_title(self, context):
         return "Update {}".format(context["object"].title)
+
+
+class GroupingDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
+    model = Grouping
+    success_url = reverse_lazy("groupings-list")
+    template_name = "groupings/confirm_delete.html"
+    page_title = "Confirm Delete"
 
 
 class AquilaLoginView(PageTitleMixin, LoginView):

--- a/setup_user.py
+++ b/setup_user.py
@@ -5,5 +5,5 @@ if not User.objects.filter(username="test").exists():
     print("Creating user")
     User.objects.create_user("test", "test@example.com", "testpassword")
     user = User.objects.get(username='test')
-    group = Group.objects.get(name='edit')
-    user.groups.add(group)
+    groups = Group.objects.filter(name__in=['edit', 'delete'])
+    user.groups.add(*groups)


### PR DESCRIPTION
Allows users in the `delete` group to delete Grouping and RightsShell instances.
- Adds delete views for Groupings and Rights Shells, and uses the `DeleteMixin` to ensure only users in the `delete` group have access to these views
- Add delete views to URL config
- Adds delete button to detail template and confirm templates

fixes #83 