### PR TITLE
Send JSON back to an external app

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -32,6 +32,7 @@ class RightsAssembler(object):
                     grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
                 serialized_shell["rights_granted"] = grant_data
                 shell_data.append(serialized_shell)
+            return shell_data
         except RightsShell.DoesNotExist as e:
             raise Exception("Error retrieving rights shell: {}".format(str(e)))
         except ValueError as e:
@@ -94,7 +95,3 @@ class RightsAssembler(object):
         serializer = serializer_class(obj)
         bytes = JSONRenderer().render(serializer.data)
         return json.loads(bytes.decode("utf-8"))
-
-    def return_rights(self):
-        """docstring for return_rights"""
-    pass


### PR DESCRIPTION
This fixes the basic requirement of #49 by returning the `shell_data` array in the `run` method. Anything that would be handled the placeholder `retrieve_rights` method is already in the `run` method. There are some issues with the content of the `rights_data` that will require new issues (this is related to #47).