### PR TITLE
Build out rights shell creation related methods in test helpers

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -25,10 +25,10 @@ class RightsAssembler(object):
             shell_data = []
             for shell in rights_shells:
                 grant_data = []
-                start_date, end_date = self.calculate_dates(shell, request_start_date, request_end_date)
+                start_date, end_date = self.get_dates(shell, request_start_date, request_end_date)
                 serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
                 for grant in shell.rightsgranted_set.all():
-                    start_date, end_date = self.calculate_dates(grant, request_start_date, request_end_date)
+                    start_date, end_date = self.get_dates(grant, request_start_date, request_end_date)
                     grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
                 serialized_shell["rights_granted"] = grant_data
                 shell_data.append(serialized_shell)
@@ -42,7 +42,7 @@ class RightsAssembler(object):
         """Retrieves rights shells matching identifiers."""
         return [RightsShell.objects.get(pk=ident) for ident in rights_ids]
 
-    def get_date_value(self, object, field_name, request_date, period):
+    def calculate_date_value(self, object, field_name, request_date, period):
         """Calculates the value for a date.
 
         Args:
@@ -59,7 +59,7 @@ class RightsAssembler(object):
         else:
             return getattr(object, field_name) + relativedelta(years=period)
 
-    def calculate_dates(self, object, request_start_date, request_end_date):
+    def get_dates(self, object, request_start_date, request_end_date):
         """Calculate rights start and end dates for a given object.
 
         Args:
@@ -72,10 +72,16 @@ class RightsAssembler(object):
                 representing the group of objects' start and end dates after
                 calculation.
         """
-        object_start = self.get_date_value(
-            object, "start_date", request_start_date, object.start_date_period)
-        object_end = None if object.end_date_open else self.get_date_value(
-            object, "end_date", request_end_date, object.end_date_period)
+        object_start = None
+        object_end = None
+        if getattr(object, "start_date_period"):
+            object_start = self.calculate_date_value(object, "start_date", request_start_date, object.start_date_period)
+        else:
+            object_start = getattr(object, "start_date")
+        if getattr(object, "end_date_period"):
+            object_end = self.calculate_date_value(object, "start_date", request_end_date, object.end_date_period)
+        elif getattr(object, "end_date"):
+            object_end = getattr(object, "end_date")
         return object_start, object_end
 
     def create_json(self, obj, serializer_class, obj_start, obj_end):

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -57,10 +57,10 @@ class RightsAssembler(object):
         """
         object_start = None
         object_end = None
-        if getattr(object, "start_date_period"):
-            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
-        else:
+        if getattr(object, "start_date"):
             object_start = getattr(object, "start_date")
+        else:
+            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
         if getattr(object, "end_date_period"):
             object_end = datetime.strptime(request_end_date, "%Y-%m-%d").date() + relativedelta(years=object.end_date_period)
         elif getattr(object, "end_date"):

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -24,10 +24,10 @@ class RightsAssembler(object):
         shell_data = []
         for shell in rights_shells:
             grant_data = []
-            start_date, end_date = self.calculate_dates(shell, request_start_date, request_end_date)
+            start_date, end_date = self.get_dates(shell, request_start_date, request_end_date)
             serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
             for grant in shell.rightsgranted_set.all():
-                start_date, end_date = self.calculate_dates(grant, request_start_date, request_end_date)
+                start_date, end_date = self.get_dates(grant, request_start_date, request_end_date)
                 grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
             serialized_shell["rights_granted"] = grant_data
             shell_data.append(serialized_shell)

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -42,23 +42,6 @@ class RightsAssembler(object):
         """Retrieves rights shells matching identifiers."""
         return [RightsShell.objects.get(pk=ident) for ident in rights_ids]
 
-    def calculate_date_value(self, object, field_name, request_date, period):
-        """Calculates the value for a date.
-
-        Args:
-            object (obj): the RightsShell or RightsGranted object for which a date is to be calculated.
-            field_name (str): the object attribute containing date data.
-            request_date (str): string representation of a date in ISO format.
-            period (int): the number of years to be used in calculating the date.
-
-        Returns:
-            A date object representation of the date after calculation.
-        """
-        if not getattr(object, field_name):
-            return datetime.strptime(request_date, "%Y-%m-%d").date() + relativedelta(years=period)
-        else:
-            return getattr(object, field_name) + relativedelta(years=period)
-
     def get_dates(self, object, request_start_date, request_end_date):
         """Calculate rights start and end dates for a given object.
 
@@ -75,11 +58,11 @@ class RightsAssembler(object):
         object_start = None
         object_end = None
         if getattr(object, "start_date_period"):
-            object_start = self.calculate_date_value(object, "start_date", request_start_date, object.start_date_period)
+            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
         else:
             object_start = getattr(object, "start_date")
         if getattr(object, "end_date_period"):
-            object_end = self.calculate_date_value(object, "start_date", request_end_date, object.end_date_period)
+            object_end = datetime.strptime(request_end_date, "%Y-%m-%d").date() + relativedelta(years=object.end_date_period)
         elif getattr(object, "end_date"):
             object_end = getattr(object, "end_date")
         return object_start, object_end

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -67,9 +67,9 @@ def add_rights_shells(count=15):
             new_shell.jurisdiction = "us"
         if basis == "copyright":
             new_shell.copyright_status = random.choice(["copyrighted", "public domain", "unknown"])
-        if basis == "statute":
+        elif basis == "statute":
             new_shell.statute_citation = random_string()
-        if basis == "license":
+        elif basis == "license":
             new_shell.license_terms = random_string()
         new_shell.save()
 

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -60,17 +60,18 @@ def set_dates():
 def add_rights_shells(count=15):
     for x in range(count):
         start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
-        new_shell = RightsShell.objects.create(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
+        new_shell = RightsShell(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
         basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
         setattr(new_shell, "rights_basis", basis)
         if basis in ["copyright", "statute"]:
-            setattr(new_shell, "jurisdiction", "us")
+            new_shell.jurisdiction = "us"
         if basis == "copyright":
-            setattr(new_shell, "copyright_status", random.choice(["copyrighted", "public domain", "unknown"]))
+            new_shell.copyright_status = random.choice(["copyrighted", "public domain", "unknown"])
         if basis == "statute":
-            setattr(new_shell, "statute_citation", random_string())
+            new_shell.statute_citation = random_string()
         if basis == "license":
-            setattr(new_shell, "license_terms", random_string())
+            new_shell.license_terms = random_string()
+        new_shell.save()
 
 
 def add_rights_acts(count=5):

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -45,10 +45,10 @@ def set_dates():
     if choice == 1:
         start_date = random_date(100, 25)
         end_date = random_date(24, -50)
-    if choice == 2:
+    elif choice == 2:
         start_date = random_date(100, 25)
         end_date_period = random.randint(20, 75)
-    if choice == 3:
+    elif choice == 3:
         start_date_period = random.randint(0, 10)
         end_date_period = random.randint(20, 75)
     else:

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -34,31 +34,103 @@ def add_groupings(count=5):
                 grouping.rights_shells.add(random.choice(RightsShell.objects.all()))
 
 
+def set_dates():
+    """Returns start and end dates in a way consistent with what is allowed in forms"""
+    start_date = None
+    end_date = None
+    start_date_period = None
+    end_date_period = None
+    end_date_open = False
+    choice = random.randrange(1, 5)
+    if choice == 1:
+        start_date = random_date(100, 25)
+        end_date = random_date(24, -50)
+    if choice == 2:
+        start_date = random_date(100, 25)
+        end_date_period = random.randint(20, 75)
+    if choice == 3:
+        start_date_period = random.randint(0, 10)
+        end_date_period = random.randint(20, 75)
+    else:
+        start_date_period = random.randint(0, 10)
+        end_date_open = True
+    return start_date, end_date, start_date_period, end_date_period, end_date_open
+
+
 def add_rights_shells(count=15):
-    for x in range(count):
+    def copyright_shell():
+        date_info = set_dates()
         RightsShell.objects.create(
-            rights_basis=random.choice([b[0] for b in RightsShell.RIGHTS_BASIS_CHOICES]),
-            copyright_status="copyrighted",
+            rights_basis="copyright",
+            copyright_status=random.choice(["copyrighted", "public domain", "unknown"]),
+            jurisdiction="us",
             determination_date=random_date(10, 0),
             note=random_string(),
-            start_date=random.choice([None, random_date(100, 25)]),
-            end_date=random.choice([None, random_date(24, -50)]),
-            start_date_period=random.randint(0, 10),
-            end_date_period=random.randint(0, 10),
-            end_date_open=random.choice([True, False]),
-            license_terms=None,
-            statute_citation=None)
+            start_date=date_info[0],
+            end_date=date_info[1],
+            start_date_period=date_info[2],
+            end_date_period=date_info[3],
+            end_date_open=date_info[4],
+        )
+
+    def other_shell():
+        date_info = set_dates()
+        RightsShell.objects.create(
+            rights_basis=random.choice(["policy", "donor"]),
+            determination_date=random_date(10, 0),
+            note=random_string(),
+            start_date=date_info[0],
+            end_date=date_info[1],
+            start_date_period=date_info[2],
+            end_date_period=date_info[3],
+            end_date_open=date_info[4],
+        )
+
+    def statute_shell():
+        date_info = set_dates()
+        RightsShell.objects.create(
+            rights_basis="statute",
+            jurisdiction="us",
+            determination_date=random_date(10, 0),
+            note=random_string(),
+            start_date=date_info[0],
+            end_date=date_info[1],
+            start_date_period=date_info[2],
+            end_date_period=date_info[3],
+            end_date_open=date_info[4],
+            statute_citation=random_string(),
+        )
+
+    def license_shell():
+        date_info = set_dates()
+        RightsShell.objects.create(
+            rights_basis="license",
+            jurisdiction="us",
+            determination_date=random_date(10, 0),
+            note=random_string(),
+            start_date=date_info[0],
+            end_date=date_info[1],
+            start_date_period=date_info[2],
+            end_date_period=date_info[3],
+            end_date_open=date_info[4],
+            license_terms=random_string(),
+        )
+
+    shell_types = [copyright_shell, other_shell, statute_shell, license_shell]
+    for x in range(count):
+        random.choice(shell_types)()
 
 
 def add_rights_acts(count=5):
     for x in range(count):
+        date_info = set_dates()
         RightsGranted.objects.create(
             basis=random.choice(RightsShell.objects.all()),
             act=random.choice(["publish", "disseminate", "replicate", "migrate", "modify", "use", "delete"]),
             restriction=random.choice(["allow", "disallow", "conditional"]),
-            start_date=random.choice([None, random_date(50, 5)]),
-            end_date=random.choice([None, random_date(4, -50)]),
-            start_date_period=random.randint(0, 10),
-            end_date_period=random.randint(0, 10),
-            end_date_open=random.choice([True, False]),
+            start_date=date_info[0],
+            end_date=date_info[1],
+            start_date_period=date_info[2],
+            end_date_period=date_info[3],
+            end_date_open=date_info[4],
         )

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -58,79 +58,31 @@ def set_dates():
 
 
 def add_rights_shells(count=15):
-    def copyright_shell():
-        date_info = set_dates()
-        RightsShell.objects.create(
-            rights_basis="copyright",
-            copyright_status=random.choice(["copyrighted", "public domain", "unknown"]),
-            jurisdiction="us",
-            determination_date=random_date(10, 0),
-            note=random_string(),
-            start_date=date_info[0],
-            end_date=date_info[1],
-            start_date_period=date_info[2],
-            end_date_period=date_info[3],
-            end_date_open=date_info[4],
-        )
-
-    def other_shell():
-        date_info = set_dates()
-        RightsShell.objects.create(
-            rights_basis=random.choice(["policy", "donor"]),
-            determination_date=random_date(10, 0),
-            note=random_string(),
-            start_date=date_info[0],
-            end_date=date_info[1],
-            start_date_period=date_info[2],
-            end_date_period=date_info[3],
-            end_date_open=date_info[4],
-        )
-
-    def statute_shell():
-        date_info = set_dates()
-        RightsShell.objects.create(
-            rights_basis="statute",
-            jurisdiction="us",
-            determination_date=random_date(10, 0),
-            note=random_string(),
-            start_date=date_info[0],
-            end_date=date_info[1],
-            start_date_period=date_info[2],
-            end_date_period=date_info[3],
-            end_date_open=date_info[4],
-            statute_citation=random_string(),
-        )
-
-    def license_shell():
-        date_info = set_dates()
-        RightsShell.objects.create(
-            rights_basis="license",
-            jurisdiction="us",
-            determination_date=random_date(10, 0),
-            note=random_string(),
-            start_date=date_info[0],
-            end_date=date_info[1],
-            start_date_period=date_info[2],
-            end_date_period=date_info[3],
-            end_date_open=date_info[4],
-            license_terms=random_string(),
-        )
-
-    shell_types = [copyright_shell, other_shell, statute_shell, license_shell]
     for x in range(count):
-        random.choice(shell_types)()
+        start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
+        new_shell = RightsShell.objects.create(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
+        basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
+        setattr(new_shell, "rights_basis", basis)
+        if basis in ["copyright", "statute"]:
+            setattr(new_shell, "jurisdiction", "us")
+        if basis == "copyright":
+            setattr(new_shell, "copyright_status", random.choice(["copyrighted", "public domain", "unknown"]))
+        if basis == "statute":
+            setattr(new_shell, "statute_citation", random_string())
+        if basis == "license":
+            setattr(new_shell, "license_terms", random_string())
 
 
 def add_rights_acts(count=5):
     for x in range(count):
-        date_info = set_dates()
+        start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
         RightsGranted.objects.create(
             basis=random.choice(RightsShell.objects.all()),
             act=random.choice(["publish", "disseminate", "replicate", "migrate", "modify", "use", "delete"]),
             restriction=random.choice(["allow", "disallow", "conditional"]),
-            start_date=date_info[0],
-            end_date=date_info[1],
-            start_date_period=date_info[2],
-            end_date_period=date_info[3],
-            end_date_open=date_info[4],
+            start_date=start_date,
+            end_date=end_date,
+            start_date_period=start_date_period,
+            end_date_period=end_date_period,
+            end_date_open=end_date_open,
         )

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -7,9 +7,15 @@ from dateutil.relativedelta import relativedelta
 from .models import Grouping, RightsGranted, RightsShell
 
 
-def random_date():
+def random_date(earliest, latest):
+    """Takes a range of years from today's date and returns a random date.
+
+    Args:
+    earliest (integer): start of range to pick a random integer from
+    latest (integer): end of range to pick a random integer from
+    """
     now = date.today()
-    r = now - relativedelta(years=random.randint(2, 50))
+    r = now - relativedelta(years=random.randint(latest, earliest))
     return r
 
 
@@ -33,10 +39,10 @@ def add_rights_shells(count=15):
         RightsShell.objects.create(
             rights_basis=random.choice([b[0] for b in RightsShell.RIGHTS_BASIS_CHOICES]),
             copyright_status="copyrighted",
-            determination_date=random_date(),
+            determination_date=random_date(10, 0),
             note=random_string(),
-            start_date=random.choice([None, random_date()]),
-            end_date=random.choice([None, random_date()]),
+            start_date=random.choice([None, random_date(100, 25)]),
+            end_date=random.choice([None, random_date(24, -50)]),
             start_date_period=random.randint(0, 10),
             end_date_period=random.randint(0, 10),
             end_date_open=random.choice([True, False]),
@@ -50,8 +56,8 @@ def add_rights_acts(count=5):
             basis=random.choice(RightsShell.objects.all()),
             act=random.choice(["publish", "disseminate", "replicate", "migrate", "modify", "use", "delete"]),
             restriction=random.choice(["allow", "disallow", "conditional"]),
-            start_date=random.choice([None, random_date()]),
-            end_date=random.choice([None, random_date()]),
+            start_date=random.choice([None, random_date(50, 5)]),
+            end_date=random.choice([None, random_date(4, -50)]),
             start_date_period=random.randint(0, 10),
             end_date_period=random.randint(0, 10),
             end_date_open=random.choice([True, False]),

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -62,7 +62,7 @@ def add_rights_shells(count=15):
         start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
         new_shell = RightsShell(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
         basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
-        setattr(new_shell, "rights_basis", basis)
+        new_shell.rights_basis = basis
         if basis in ["copyright", "statute"]:
             new_shell.jurisdiction = "us"
         if basis == "copyright":

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -166,8 +166,8 @@ class TestRightsAssembler(TestCase):
 
     def test_run_method(self):
         """Tests the run method"""
-        request_end_date = random_date().isoformat()
-        request_start_date = random_date().isoformat()
+        request_end_date = random_date(49, 0).isoformat()
+        request_start_date = random_date(100, 50).isoformat()
         run = RightsAssembler().run(self.rights_ids, request_start_date, request_end_date)
         self.assertIsNot(False, run)
 
@@ -194,8 +194,8 @@ class TestRightsAssembler(TestCase):
         is equal to the end date period of the object.
         """
         object.end_date_open = False
-        object.start_date = random_date()
-        object.end_date = random_date()
+        object.start_date = random_date(125, 50)
+        object.end_date = random_date(50, 10)
         start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
         self.assertEqual(relativedelta(start_date, object.start_date).years, object.start_date_period)
         self.assertTrue(isinstance(start_date, date))
@@ -225,8 +225,8 @@ class TestRightsAssembler(TestCase):
     def test_calculate_dates(self):
         """Tests the calculate_dates method."""
         shell = random.choice(RightsShell.objects.all())
-        request_end_date = random_date().isoformat()
-        request_start_date = random_date().isoformat()
+        request_end_date = random_date(49, 0).isoformat()
+        request_start_date = random_date(100, 50).isoformat()
         self.check_object_dates(shell, request_start_date, request_end_date)
 
         for granted in shell.rightsgranted_set.all():
@@ -238,8 +238,8 @@ class TestRightsAssembler(TestCase):
                 (RightsShell, RightsShellSerializer),
                 (RightsGranted, RightsGrantedSerializer)]:
             obj = random.choice(obj_cls.objects.all())
-            start_date = random_date().isoformat()
-            end_date = random_date().isoformat()
+            start_date = random_date(75, 50).isoformat()
+            end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, serializer_cls, start_date, end_date)
             self.assertTrue(isinstance(serialized, dict))
             self.assertEqual(start_date, serialized["start_date"])

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -196,15 +196,16 @@ class TestRightsAssembler(TestCase):
         object.end_date_open = False
         object.start_date = random_date(125, 50)
         object.end_date = random_date(50, 10)
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(relativedelta(start_date, object.start_date).years, object.start_date_period)
         self.assertTrue(isinstance(start_date, date))
-        self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
+        if object.end_date_period:
+            self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
         self.assertTrue(isinstance(end_date, date))
 
         object.start_date = None
         object.end_date = None
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(relativedelta(
             start_date,
             datetime.strptime(request_start_date, "%Y-%m-%d").date()).years,
@@ -219,11 +220,11 @@ class TestRightsAssembler(TestCase):
         self.assertTrue(isinstance(end_date, date))
 
         object.end_date_open = True
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(end_date, None)
 
-    def test_calculate_dates(self):
-        """Tests the calculate_dates method."""
+    def test_get_dates(self):
+        """Tests the get_dates method."""
         shell = random.choice(RightsShell.objects.all())
         request_end_date = random_date(49, 0).isoformat()
         request_start_date = random_date(100, 50).isoformat()

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -193,35 +193,17 @@ class TestRightsAssembler(TestCase):
         Asserts that the relative delta of the calculated date and the correct end date
         is equal to the end date period of the object.
         """
-        object.end_date_open = False
-        object.start_date = random_date(125, 50)
-        object.end_date = random_date(50, 10)
         start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(relativedelta(start_date, object.start_date).years, object.start_date_period)
         self.assertTrue(isinstance(start_date, date))
+        if object.end_date_open:
+            self.assertEqual(end_date, None)
+        else:
+            self.assertTrue(isinstance(end_date, date))
+
+        if object.start_date_period:
+            self.assertEqual(relativedelta(start_date, datetime.strptime(request_start_date, "%Y-%m-%d").date()).years, object.start_date_period)
         if object.end_date_period:
-            self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
-        self.assertTrue(isinstance(end_date, date))
-
-        object.start_date = None
-        object.end_date = None
-        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(relativedelta(
-            start_date,
-            datetime.strptime(request_start_date, "%Y-%m-%d").date()).years,
-            object.start_date_period
-        )
-        self.assertTrue(isinstance(start_date, date))
-        self.assertEqual(relativedelta(
-            end_date,
-            datetime.strptime(request_end_date, "%Y-%m-%d").date()).years,
-            object.end_date_period
-        )
-        self.assertTrue(isinstance(end_date, date))
-
-        object.end_date_open = True
-        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(end_date, None)
+            self.assertEqual(relativedelta(end_date, datetime.strptime(request_end_date, "%Y-%m-%d").date()).years, object.end_date_period)
 
     def test_get_dates(self):
         """Tests the get_dates method."""

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -35,6 +35,7 @@ class TestRightsAssemblyView(TransactionTestCase):
         self.api_factory = APIRequestFactory()
         self.factory = RequestFactory()
         add_rights_shells()
+        add_rights_acts()
 
     def test_rightsassembly_view(self):
         """Tests handling of expected returns as well as exceptions."""

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -160,7 +160,7 @@ class TestViews(TestCase):
 class TestRightsAssembler(TestCase):
     def setUp(self):
         add_rights_shells()
-        add_rights_acts(count=15)
+        add_rights_acts()
         self.assembler = RightsAssembler()
         self.rights_ids = [obj.pk for obj in RightsShell.objects.all()]
 

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -160,7 +160,7 @@ class TestViews(TestCase):
 class TestRightsAssembler(TestCase):
     def setUp(self):
         add_rights_shells()
-        add_rights_acts()
+        add_rights_acts(count=15)
         self.assembler = RightsAssembler()
         self.rights_ids = [obj.pk for obj in RightsShell.objects.all()]
 


### PR DESCRIPTION
Makes three changes so that rights shells and acts created as part of setting up tests more closely mimic what would be created by users using the forms.

1. Builds out `random_date` method to take arguments, so that we can more closely target start dates and end dates.
2. Adds a `set_dates` method so that rights shells and acts only have one start date and one end date.
3. Create separate methods for different types of rights bases, so that only the correct fields are associated with each.

It looks like tests are passing on the latest commit, but when I ran tests locally these changes caused the `test_calculate_dates` method to fail. I documented this in #113; fixing it requires some changes in assembler.py as well as the tests, which will happen in a PR branched off of this.

Fixes #111