### PR TITLE
Improve http status codes thrown on exception

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -20,23 +20,18 @@ class RightsAssembler(object):
             request_start_date (string): a string representation of the earliest date of a group of records
             request_end_date (string): a string representation of the latest date of a group of records
         """
-        try:
-            rights_shells = self.retrieve_rights(rights_ids)
-            shell_data = []
-            for shell in rights_shells:
-                grant_data = []
-                start_date, end_date = self.calculate_dates(shell, request_start_date, request_end_date)
-                serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
-                for grant in shell.rightsgranted_set.all():
-                    start_date, end_date = self.calculate_dates(grant, request_start_date, request_end_date)
-                    grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
-                serialized_shell["rights_granted"] = grant_data
-                shell_data.append(serialized_shell)
-            return shell_data
-        except RightsShell.DoesNotExist as e:
-            raise Exception("Error retrieving rights shell: {}".format(str(e)))
-        except ValueError as e:
-            raise Exception("Unable to parse date: {}".format(e))
+        rights_shells = self.retrieve_rights(rights_ids)
+        shell_data = []
+        for shell in rights_shells:
+            grant_data = []
+            start_date, end_date = self.calculate_dates(shell, request_start_date, request_end_date)
+            serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
+            for grant in shell.rightsgranted_set.all():
+                start_date, end_date = self.calculate_dates(grant, request_start_date, request_end_date)
+                grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
+            serialized_shell["rights_granted"] = grant_data
+            shell_data.append(serialized_shell)
+        return shell_data
 
     def retrieve_rights(self, rights_ids):
         """Retrieves rights shells matching identifiers."""

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -48,12 +48,14 @@ class TestRightsAssemblyView(TransactionTestCase):
                 self.assertEqual(response.status_code, 200, "Request error: {}".format(response.data))
 
         # RightsAssembler throws an exception
-        for fixture_name, message in [("invalid_rights_id.json", "Error retrieving rights shell: RightsShell matching query does not exist."), ("no_start_date.json", "Request data must contain 'identifiers', 'start_date' and 'end_date' keys.")]:
+        for fixture_name, message, status_code in [
+                ("invalid_rights_id.json", "Error retrieving rights shell: RightsShell matching query does not exist.", 404),
+                ("no_start_date.json", "Request data must contain 'identifiers', 'start_date' and 'end_date' keys.", 400)]:
             with open(join(invalid_data_fixture_dir, fixture_name), 'r') as json_file:
                 invalid_data = json.load(json_file)
                 request = self.factory.post(reverse("rights-assemble"), invalid_data, content_type='application/json')
                 response = RightsAssemblerView.as_view()(request)
-                self.assertEqual(response.status_code, 500, "Request should have returned a 500 status code")
+                self.assertEqual(response.status_code, status_code, "Request should have returned a {} status code".format(status_code))
                 self.assertEqual(response.data["detail"], message)
 
 

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -203,9 +203,13 @@ class RightsAssemblerView(APIView):
         if not all([rights_ids, request_start_date, request_end_date]):
             return Response(
                 {"detail": "Request data must contain 'identifiers', 'start_date' and 'end_date' keys."},
-                status=500)
+                status=400)
         try:
             rights = RightsAssembler().run(rights_ids, request_start_date, request_end_date)
             return Response({"rights_statements": rights}, status=200)
+        except RightsShell.DoesNotExist as e:
+            return Response({"detail": "Error retrieving rights shell: {}".format(str(e))}, status=404)
+        except ValueError as e:
+            return Response({"detail": "Unable to parse date: {}".format(e)}, status=500)
         except Exception as e:
             return Response({"detail": str(e)}, status=500)


### PR DESCRIPTION
Throws a 404 if request asks for a rights shell that doesn't exist, and a 400 if parameters are missing. In all other cases it will throw a 500.

Fixes #110 