### PR TITLE
Handle dates, not just terms in RightsAssembler

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -25,10 +25,10 @@ class RightsAssembler(object):
             shell_data = []
             for shell in rights_shells:
                 grant_data = []
-                start_date, end_date = self.calculate_dates(shell, request_start_date, request_end_date)
+                start_date, end_date = self.get_dates(shell, request_start_date, request_end_date)
                 serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
                 for grant in shell.rightsgranted_set.all():
-                    start_date, end_date = self.calculate_dates(grant, request_start_date, request_end_date)
+                    start_date, end_date = self.get_dates(grant, request_start_date, request_end_date)
                     grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
                 serialized_shell["rights_granted"] = grant_data
                 shell_data.append(serialized_shell)
@@ -42,7 +42,7 @@ class RightsAssembler(object):
         """Retrieves rights shells matching identifiers."""
         return [RightsShell.objects.get(pk=ident) for ident in rights_ids]
 
-    def get_date_value(self, object, field_name, request_date, period):
+    def calculate_date_value(self, object, field_name, request_date, period):
         """Calculates the value for a date.
 
         Args:
@@ -59,7 +59,7 @@ class RightsAssembler(object):
         else:
             return getattr(object, field_name) + relativedelta(years=period)
 
-    def calculate_dates(self, object, request_start_date, request_end_date):
+    def get_dates(self, object, request_start_date, request_end_date):
         """Calculate rights start and end dates for a given object.
 
         Args:
@@ -72,10 +72,16 @@ class RightsAssembler(object):
                 representing the group of objects' start and end dates after
                 calculation.
         """
-        object_start = self.get_date_value(
-            object, "start_date", request_start_date, object.start_date_period)
-        object_end = None if object.end_date_open else self.get_date_value(
-            object, "end_date", request_end_date, object.end_date_period)
+        object_start = None
+        object_end = None
+        if getattr(object, "start_date_period"):
+            object_start = self.calculate_date_value(object, "start_date", request_start_date, object.start_date_period)
+        else:
+            object_start = getattr(object, "start_date")
+        if getattr(object, "end_date_period"):
+            object_end = self.calculate_date_value(object, "start_date", request_end_date, object.end_date_period)
+        elif getattr(object, "end_date"):
+            object_end = getattr(object, "end_date")
         return object_start, object_end
 
     def create_json(self, obj, serializer_class, obj_start, obj_end):

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -57,10 +57,10 @@ class RightsAssembler(object):
         """
         object_start = None
         object_end = None
-        if getattr(object, "start_date_period"):
-            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
-        else:
+        if getattr(object, "start_date"):
             object_start = getattr(object, "start_date")
+        else:
+            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
         if getattr(object, "end_date_period"):
             object_end = datetime.strptime(request_end_date, "%Y-%m-%d").date() + relativedelta(years=object.end_date_period)
         elif getattr(object, "end_date"):

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -42,23 +42,6 @@ class RightsAssembler(object):
         """Retrieves rights shells matching identifiers."""
         return [RightsShell.objects.get(pk=ident) for ident in rights_ids]
 
-    def calculate_date_value(self, object, field_name, request_date, period):
-        """Calculates the value for a date.
-
-        Args:
-            object (obj): the RightsShell or RightsGranted object for which a date is to be calculated.
-            field_name (str): the object attribute containing date data.
-            request_date (str): string representation of a date in ISO format.
-            period (int): the number of years to be used in calculating the date.
-
-        Returns:
-            A date object representation of the date after calculation.
-        """
-        if not getattr(object, field_name):
-            return datetime.strptime(request_date, "%Y-%m-%d").date() + relativedelta(years=period)
-        else:
-            return getattr(object, field_name) + relativedelta(years=period)
-
     def get_dates(self, object, request_start_date, request_end_date):
         """Calculate rights start and end dates for a given object.
 
@@ -75,11 +58,11 @@ class RightsAssembler(object):
         object_start = None
         object_end = None
         if getattr(object, "start_date_period"):
-            object_start = self.calculate_date_value(object, "start_date", request_start_date, object.start_date_period)
+            object_start = datetime.strptime(request_start_date, "%Y-%m-%d").date() + relativedelta(years=object.start_date_period)
         else:
             object_start = getattr(object, "start_date")
         if getattr(object, "end_date_period"):
-            object_end = self.calculate_date_value(object, "start_date", request_end_date, object.end_date_period)
+            object_end = datetime.strptime(request_end_date, "%Y-%m-%d").date() + relativedelta(years=object.end_date_period)
         elif getattr(object, "end_date"):
             object_end = getattr(object, "end_date")
         return object_start, object_end

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -45,10 +45,10 @@ def set_dates():
     if choice == 1:
         start_date = random_date(100, 25)
         end_date = random_date(24, -50)
-    if choice == 2:
+    elif choice == 2:
         start_date = random_date(100, 25)
         end_date_period = random.randint(20, 75)
-    if choice == 3:
+    elif choice == 3:
         start_date_period = random.randint(0, 10)
         end_date_period = random.randint(20, 75)
     else:

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -196,15 +196,16 @@ class TestRightsAssembler(TestCase):
         object.end_date_open = False
         object.start_date = random_date(125, 50)
         object.end_date = random_date(50, 10)
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(relativedelta(start_date, object.start_date).years, object.start_date_period)
         self.assertTrue(isinstance(start_date, date))
-        self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
+        if object.end_date_period:
+            self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
         self.assertTrue(isinstance(end_date, date))
 
         object.start_date = None
         object.end_date = None
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(relativedelta(
             start_date,
             datetime.strptime(request_start_date, "%Y-%m-%d").date()).years,
@@ -219,11 +220,11 @@ class TestRightsAssembler(TestCase):
         self.assertTrue(isinstance(end_date, date))
 
         object.end_date_open = True
-        start_date, end_date = self.assembler.calculate_dates(object, request_start_date, request_end_date)
+        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
         self.assertEqual(end_date, None)
 
-    def test_calculate_dates(self):
-        """Tests the calculate_dates method."""
+    def test_get_dates(self):
+        """Tests the get_dates method."""
         shell = random.choice(RightsShell.objects.all())
         request_end_date = random_date(49, 0).isoformat()
         request_start_date = random_date(100, 50).isoformat()

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -193,35 +193,17 @@ class TestRightsAssembler(TestCase):
         Asserts that the relative delta of the calculated date and the correct end date
         is equal to the end date period of the object.
         """
-        object.end_date_open = False
-        object.start_date = random_date(125, 50)
-        object.end_date = random_date(50, 10)
         start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(relativedelta(start_date, object.start_date).years, object.start_date_period)
         self.assertTrue(isinstance(start_date, date))
+        if object.end_date_open:
+            self.assertEqual(end_date, None)
+        else:
+            self.assertTrue(isinstance(end_date, date))
+
+        if object.start_date_period:
+            self.assertEqual(relativedelta(start_date, datetime.strptime(request_start_date, "%Y-%m-%d").date()).years, object.start_date_period)
         if object.end_date_period:
-            self.assertEqual(relativedelta(end_date, object.end_date).years, object.end_date_period)
-        self.assertTrue(isinstance(end_date, date))
-
-        object.start_date = None
-        object.end_date = None
-        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(relativedelta(
-            start_date,
-            datetime.strptime(request_start_date, "%Y-%m-%d").date()).years,
-            object.start_date_period
-        )
-        self.assertTrue(isinstance(start_date, date))
-        self.assertEqual(relativedelta(
-            end_date,
-            datetime.strptime(request_end_date, "%Y-%m-%d").date()).years,
-            object.end_date_period
-        )
-        self.assertTrue(isinstance(end_date, date))
-
-        object.end_date_open = True
-        start_date, end_date = self.assembler.get_dates(object, request_start_date, request_end_date)
-        self.assertEqual(end_date, None)
+            self.assertEqual(relativedelta(end_date, datetime.strptime(request_end_date, "%Y-%m-%d").date()).years, object.end_date_period)
 
     def test_get_dates(self):
         """Tests the get_dates method."""

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -160,7 +160,7 @@ class TestViews(TestCase):
 class TestRightsAssembler(TestCase):
     def setUp(self):
         add_rights_shells()
-        add_rights_acts(count=15)
+        add_rights_acts()
         self.assembler = RightsAssembler()
         self.rights_ids = [obj.pk for obj in RightsShell.objects.all()]
 

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -160,7 +160,7 @@ class TestViews(TestCase):
 class TestRightsAssembler(TestCase):
     def setUp(self):
         add_rights_shells()
-        add_rights_acts()
+        add_rights_acts(count=15)
         self.assembler = RightsAssembler()
         self.rights_ids = [obj.pk for obj in RightsShell.objects.all()]
 


### PR DESCRIPTION
Changes to RightsAssembler so that multiple types of dates are added. Updates tests accordingly, including simplifying the check_object_dates method.

Fixes #113 