### PR TITLE
Adds additional option to start date select

### DIFF
--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -27,7 +27,8 @@ class RightsShellCommonLayout(Layout):
             Div(
                 Div(Field("rights_begin", v_model="rightsBegin"), css_class="col-5"),
                 Div(Field("start_date", pattern=r"\d{4}-\d{2}-\d{2}", required="required"), css_class="col-4", v_if="rightsBegin=='start_date'"),
-                Div(Field("start_date_period", required="required"), css_class="col-4", v_if="rightsBegin=='start_date_period'"), css_class="row"),
+                Div(Field("start_date_period", required="required"), css_class="col-4", v_if="rightsBegin=='start_date_period'"),
+                Div(Hidden(name="start_date_period", value="0"), v_if="rightsBegin=='start_date_period_zero'"), css_class="row"),
             Div(
                 Div(Field("rights_end", v_model="rightsEnd"), css_class="col-5"),
                 Div(Field("end_date", pattern=r"\d{4}-\d{2}-\d{2}", required="required"), css_class="col-4", v_if="rightsEnd=='end_date'"),
@@ -50,7 +51,8 @@ class RightsShellForm(ModelForm):
         label="Start of Rights",
         choices=(("", "---------"),
                  ("start_date", "These rights start on a specific date"),
-                 ("start_date_period", "These rights start after an embargo period")))
+                 ("start_date_period", "These rights start after an embargo period"),
+                 ("start_date_period_zero", "These rights start on creation date of materials")))
     rights_end = ChoiceField(
         label="End of Rights",
         choices=(("", "---------"),

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -36,6 +36,10 @@
   <dt class="col-sm-2">Start Date Embargo Period (in years)</dt>
   <dd class="col-sm-10">{{ rightsshell.start_date_period }}</dd>
   {% endif %}
+  {% if rightsshell.start_date_period == 0 %}
+  <dt class="col-sm-2">Start Date</dt>
+  <dd class="col-sm-10">Date of creation of materials</dd>
+  {% endif %}
   {% if rightsshell.end_date %}
   <dt class="col-sm-2">End Date</dt>
   <dd class="col-sm-10">{{ rightsshell.end_date }}</dd>
@@ -69,6 +73,10 @@
         {% if rights_granted.start_date_period %}
         <dt>Start Date Embargo Period (in years)</dt>
         <dd>{{rights_granted.start_date_period}}</dd>
+        {% endif %}
+        {% if rights_granted.start_date_period == 0 %}
+        <dt>Start Date</dt>
+        <dd>Date of creation of materials</dd>
         {% endif %}
         {% if rights_granted.end_date %}
         <dt>End Date</dt>

--- a/assign_rights/templates/rights/manage.html
+++ b/assign_rights/templates/rights/manage.html
@@ -97,6 +97,7 @@
                 <option value="">-------</option>
                 <option value="start_date">This restriction starts on a specific date</option>
                 <option value="start_date_period">This restriction starts after an embargo period</option>
+                <option value="start_date_period_zero">This restriction starts on creation date of materials</option>
               </select>
             </div>
             <div v-if="rights_granted.restriction_begin == 'start_date'" class="form-group col-4">
@@ -122,6 +123,12 @@
                      v-bind:id="'id_rightsgranted_set-'+rights_granted.rights_granted_formset_index+'-start_date_period'"
                      class="form-control"
                      required="required">
+            </div>
+            <div v-if="rights_granted.restriction_begin == 'start_date_period_zero'" class="form-group col-4">
+              <input type="hidden"
+                     v-bind:name="'rightsgranted_set-'+rights_granted.rights_granted_formset_index+'-start_date_period'"
+                     v-bind:id="'id_rightsgranted_set-'+rights_granted.rights_granted_formset_index+'-start_date_period'"
+                     value="0">
             </div>
           </div>
 
@@ -211,7 +218,7 @@
             marked_for_delete: false,
             act: '{{ nested_form.act.value|default_if_none:"" }}',
             restriction: '{{ nested_form.restriction.value|default_if_none:"" }}',
-            restriction_begin: {% if nested_form.start_date.value %}'start_date'{% elif nested_form.start_date_period.value or nested_form.start_date_period.value == 0 %}'start_date_period'{% else %}''{% endif %},
+            restriction_begin: {% if nested_form.start_date.value %}'start_date'{% elif nested_form.start_date_period.value %}'start_date_period'{% elif nested_form.start_date_period.value == 0 %}'start_date_period_zero'{% else %}''{% endif %},
             restriction_end: {% if nested_form.end_date.value %}'end_date'{% elif nested_form.end_date_period.value or nested_form.end_date_period.value == 0 %}'end_date_period'{% elif nested_form.end_date_open.value %}'end_date_open'{% else %}''{% endif %},
             start_date: '{{ nested_form.start_date.value|isoformat_date_or_string|default_if_none:"" }}',
             start_date_error: '{{ nested_form.errors.start_date|default_if_none:"" }}',
@@ -233,9 +240,11 @@
       rightsBasisSelected: '{{ form.rights_basis.value|default_if_none:""}}',
       rights_basis: rights_basis,
       rightsBegin: {% if basis_form.start_date.value %}'start_date'
-                   {% elif basis_form.start_date_period.value or basis_form.start_date_period.value == 0 %}'start_date_period'
+                   {% elif basis_form.start_date_period.value %}'start_date_period'
+                   {% elif basis_form.start_date_period.value == 0 %}'start_date_period_zero'
                    {% elif form.start_date.value %}'start_date'
-                   {% elif form.start_date_period.value or basis_form.start_date_period.value == 0 %}'start_date_period'
+                   {% elif form.start_date_period.value%}'start_date_period'
+                   {% elif basis_form.start_date_period.value == 0 %}'start_date_period_zero'
                    {% else %}''
                    {% endif %},
       rightsEnd: {% if basis_form.end_date.value %}'end_date'


### PR DESCRIPTION
Adds an option to the start date selects for both rights bases and acts which sets a `start_date_period` of zero years. While doing this, I also noticed that the detail pages don't display anything if the `start_date_period` value is zero, so I added some logic and custom display for that case.

fixes #127 