### PR TITLE
Better indication of rights IDs

### DIFF
--- a/assign_rights/models.py
+++ b/assign_rights/models.py
@@ -50,7 +50,7 @@ class RightsShell(models.Model):
         note = self.note
         if len(note) > 115:
             note = "{}...".format(note[:75]) if len(note) > 75 else note
-        return "{} - {} ({})".format(self.pk, " / ".join([p for p in prefixes if p]), note)
+        return "ID# {} - {} ({})".format(self.pk, " / ".join([p for p in prefixes if p]), note)
 
 
 class RightsGranted(models.Model):

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -12,6 +12,8 @@
 
 <h2>Details</h2>
 <dl class="row">
+  <dt class="col-sm-2">Identifier</dt>
+  <dd class="col-sm-10">{{ rightsshell.pk }}</dd>
   <dt class="col-sm-2">Basis</dt>
   <dd class="col-sm-10">{{ rightsshell.rights_basis }}</dd>
   {% if rightsshell.get_rights_basis_display == "Copyright" %}


### PR DESCRIPTION
Fixes #126 

This adds "ID#" before all instances of the rights statement ID and the labeled identifier to the rights detail page. I didn't remove the note text on the Groupings page, because I'm wondering if consistency across the app is a plus, ie. every time the user sees this, the same information is clearly associated.

Take a look - I'm open to disagreement on this approach!