### PR TITLE
Improve selecting multiple rights shells when creating grouping

### DIFF
--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,7 +1,7 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Div, Field, Hidden, Layout
-from django.forms import (CheckboxSelectMultiple, ChoiceField, ModelForm, Select, Textarea, TextInput,
-                          inlineformset_factory)
+from crispy_forms.layout import Div, Field, Fieldset, Hidden, Layout
+from django.forms import (CheckboxSelectMultiple, ChoiceField, ModelForm,
+                          Select, Textarea, TextInput, inlineformset_factory)
 from django.forms.utils import ErrorList
 
 from .models import Grouping, RightsGranted, RightsShell
@@ -40,6 +40,14 @@ class RightsShellCommonLayout(Layout):
 
 
 class GroupingForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.field_template = "forms/custom_field.html"
+        self.fields['rights_shells'].label = False
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+
     class Meta:
         model = Grouping
         fields = ["title", "description", 'rights_shells']

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,5 +1,5 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Div, Field, Fieldset, Hidden, Layout
+from crispy_forms.layout import Div, Field, Hidden, Layout
 from django.forms import (CheckboxSelectMultiple, ChoiceField, ModelForm,
                           Select, Textarea, TextInput, inlineformset_factory)
 from django.forms.utils import ErrorList

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -40,6 +40,11 @@ class RightsShellCommonLayout(Layout):
 
 
 class GroupingForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.fields['rights_shells'].label = False
+
     class Meta:
         model = Grouping
         fields = ["title", "description", 'rights_shells']

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -40,14 +40,12 @@ class RightsShellCommonLayout(Layout):
 
 
 class GroupingForm(ModelForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-        self.fields['rights_shells'].label = False
-
     class Meta:
         model = Grouping
         fields = ["title", "description", 'rights_shells']
+        labels = {
+            'rights_shells': False
+        }
         widgets = {
             'rights_shells': CheckboxSelectMultiple
         }

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -44,7 +44,7 @@ class GroupingForm(ModelForm):
         model = Grouping
         fields = ["title", "description", 'rights_shells']
         labels = {
-            'rights_shells': False
+            'rights_shells': ''  # legend is used instead of label
         }
         widgets = {
             'rights_shells': CheckboxSelectMultiple

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -40,14 +40,6 @@ class RightsShellCommonLayout(Layout):
 
 
 class GroupingForm(ModelForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-        self.helper.field_template = "forms/custom_field.html"
-        self.fields['rights_shells'].label = False
-        self.helper.form_tag = False
-        self.helper.disable_csrf = True
-
     class Meta:
         model = Grouping
         fields = ["title", "description", 'rights_shells']

--- a/assign_rights/forms.py
+++ b/assign_rights/forms.py
@@ -1,6 +1,6 @@
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Field, Hidden, Layout
-from django.forms import (ChoiceField, ModelForm, Select, Textarea, TextInput,
+from django.forms import (CheckboxSelectMultiple, ChoiceField, ModelForm, Select, Textarea, TextInput,
                           inlineformset_factory)
 from django.forms.utils import ErrorList
 
@@ -42,7 +42,10 @@ class RightsShellCommonLayout(Layout):
 class GroupingForm(ModelForm):
     class Meta:
         model = Grouping
-        fields = ["title", "description", "rights_shells"]
+        fields = ["title", "description", 'rights_shells']
+        widgets = {
+            'rights_shells': CheckboxSelectMultiple
+        }
 
 
 class RightsShellForm(ModelForm):

--- a/assign_rights/static/css/custom.css
+++ b/assign_rights/static/css/custom.css
@@ -62,3 +62,7 @@ a.btn {
   width: auto;
   z-index: 99;
 }
+
+.fixed-height {
+  max-height: 250px;
+}

--- a/assign_rights/templates/groupings/manage.html
+++ b/assign_rights/templates/groupings/manage.html
@@ -5,7 +5,14 @@
 
 <form action="." method="POST" accept-charset="utf-8">
   {% csrf_token %}
-	{{ form | crispy }}
+	{{ form.title | as_crispy_field }}
+	{{ form.description | as_crispy_field }}
+	<fieldset>
+		<legend>Choose Associated Rights Shell/s*</legend>
+		<div class="overflow-auto border p-2 mb-3" style="max-height:250px;">
+			{{ form.rights_shells | as_crispy_field }}
+		</div>
+	</fieldset>
 	<button class="btn btn-primary" type="submit">Save</button>
 </form>
 

--- a/assign_rights/templates/groupings/manage.html
+++ b/assign_rights/templates/groupings/manage.html
@@ -9,7 +9,7 @@
 	{{ form.description | as_crispy_field }}
 	<fieldset>
 		<legend>Choose Associated Rights Shell/s*</legend>
-		<div class="overflow-auto border p-2 mb-3 fixed-height">
+		<div class="overflow-auto border pt-3 px-3 mb-3 fixed-height">
 			{{ form.rights_shells | as_crispy_field }}
 		</div>
 	</fieldset>

--- a/assign_rights/templates/groupings/manage.html
+++ b/assign_rights/templates/groupings/manage.html
@@ -9,7 +9,7 @@
 	{{ form.description | as_crispy_field }}
 	<fieldset>
 		<legend>Choose Associated Rights Shell/s*</legend>
-		<div class="overflow-auto border p-2 mb-3" style="max-height:250px;">
+		<div class="overflow-auto border p-2 mb-3 fixed-height">
 			{{ form.rights_shells | as_crispy_field }}
 		</div>
 	</fieldset>


### PR DESCRIPTION
Addresses issue #130 

Implements `CheckboxSelectMultiple` for the `rights_shells` in `forms.py`. However, by default this doesn't include the `<fieldset>` and `<legend>` elements that should form a set of checkboxes (this is a [useful reference](https://a11y-style-guide.com/style-guide/section-forms.html#kssref-forms-checkboxes) for that pattern, and why it's important), so I've edited the `templates/groupings/manage.html` template to add that markup.

Also enables vertical scroll for the checkboxes after a fixed height that encompasses 10 rights shells.

