### PR TITLE
Serialize RightsShell jurisdiction to lowercase

### DIFF
--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -32,6 +32,7 @@ class RightsShellSerializer(serializers.ModelSerializer):
     terms = serializers.CharField(source="license_terms")
     citation = serializers.CharField(source="statute_citation")
     rights_granted = serializers.ListField(default=[])
+    jurisdiction = serializers.SerializerMethodField()
 
     class Meta:
         model = RightsShell
@@ -47,3 +48,6 @@ class RightsShellSerializer(serializers.ModelSerializer):
             "citation",
             "rights_granted"
         )
+
+    def get_jurisdiction(self, obj):
+        return obj.jurisdiction.lower() if obj.jurisdiction else None

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -64,7 +64,7 @@ def add_rights_shells(count=15):
         basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
         new_shell.rights_basis = basis
         if basis in ["copyright", "statute"]:
-            new_shell.jurisdiction = random.choice(["US", "us", "AU", "au"])
+            new_shell.jurisdiction = "US"
         if basis == "copyright":
             new_shell.copyright_status = random.choice(["copyrighted", "public domain", "unknown"])
         elif basis == "statute":

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -64,7 +64,7 @@ def add_rights_shells(count=15):
         basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
         new_shell.rights_basis = basis
         if basis in ["copyright", "statute"]:
-            new_shell.jurisdiction = "us"
+            new_shell.jurisdiction = random.choice(["US", "us", "AU", "au"])
         if basis == "copyright":
             new_shell.copyright_status = random.choice(["copyrighted", "public domain", "unknown"])
         elif basis == "statute":

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -228,9 +228,7 @@ class TestRightsAssembler(TestCase):
             serialized = self.assembler.create_json(obj, serializer_cls, start_date, end_date)
             if obj_cls == RightsShell:
                 if obj.jurisdiction:
-                    self.assertEqual(serialized['jurisdiction'], 'us')
-                else:
-                    self.assertEqual(serialized['jurisdiction'], None)
+                    self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))
             self.assertEqual(start_date, serialized["start_date"])
             self.assertEqual(end_date, serialized["end_date"])

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -226,6 +226,11 @@ class TestRightsAssembler(TestCase):
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, serializer_cls, start_date, end_date)
+            if obj_cls == RightsShell:
+                if obj.jurisdiction:
+                    self.assertEqual(serialized['jurisdiction'], 'us')
+                else:
+                    self.assertEqual(serialized['jurisdiction'], None)
             self.assertTrue(isinstance(serialized, dict))
             self.assertEqual(start_date, serialized["start_date"])
             self.assertEqual(end_date, serialized["end_date"])

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -93,7 +93,6 @@ class RightsShellUpdateView(PageTitleMixin, EditMixin, UpdateView):
         context["act_choices"] = RightsGranted.ACT_CHOICES
         context["restriction_choices"] = RightsGranted.RESTRICTION_CHOICES
         if self.request.POST:
-            print("here")
             context["rights_granted_form"] = RightsGrantedFormSet(
                 self.request.POST, instance=self.object, error_class=StrErrorList)
             context["basis_form"] = form_cls(self.request.POST, instance=self.object)


### PR DESCRIPTION
Use the RightsShell serializer to convert jurisdiction codes to lowercase strings.

Adds logic to test the above to the RightsAssembler test.

Fixes #129 