### PR TITLE
Add serializer to handle policy and donor bases

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -25,10 +25,10 @@ class RightsAssembler(object):
         for shell in rights_shells:
             grant_data = []
             start_date, end_date = self.get_dates(shell, request_start_date, request_end_date)
-            serialized_shell = self.create_json(shell, RightsShellSerializer, start_date, end_date)
+            serialized_shell = self.create_json(shell, start_date, end_date)
             for grant in shell.rightsgranted_set.all():
                 start_date, end_date = self.get_dates(grant, request_start_date, request_end_date)
-                grant_data.append(self.create_json(grant, RightsGrantedSerializer, start_date, end_date))
+                grant_data.append(self.create_json(grant, start_date, end_date))
             serialized_shell["rights_granted"] = grant_data
             shell_data.append(serialized_shell)
         return shell_data
@@ -62,7 +62,7 @@ class RightsAssembler(object):
             object_end = getattr(object, "end_date")
         return object_start, object_end
 
-    def create_json(self, obj, serializer_class, obj_start, obj_end):
+    def create_json(self, obj, obj_start, obj_end):
         """Runs specific serializer against an object and creates a JSON-structured dict.
 
         Args:
@@ -76,6 +76,9 @@ class RightsAssembler(object):
         """
         obj.start_date = obj_start
         obj.end_date = obj_end
-        serializer = serializer_class(obj)
+        if obj.__class__ == RightsShell:
+            serializer = RightsShellSerializer(obj)
+        else:
+            serializer = RightsGrantedSerializer(obj)
         bytes = JSONRenderer().render(serializer.data)
         return json.loads(bytes.decode("utf-8"))

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -5,7 +5,9 @@ from dateutil.relativedelta import relativedelta
 from rest_framework.renderers import JSONRenderer
 
 from .models import RightsShell
-from .serializers import RightsGrantedSerializer, RightsShellSerializer
+from .serializers import (CopyrightSerializer, LicenseSerializer,
+                          RightsGrantedSerializer, RightsShellSerializer,
+                          StatuteSerializer)
 
 
 class RightsAssembler(object):
@@ -77,7 +79,14 @@ class RightsAssembler(object):
         obj.start_date = obj_start
         obj.end_date = obj_end
         if obj.__class__ == RightsShell:
-            serializer = RightsShellSerializer(obj)
+            if obj.rights_basis == "copyright":
+                serializer = CopyrightSerializer(obj)
+            elif obj.rights_basis == "statute":
+                serializer = StatuteSerializer(obj)
+            elif obj.rights_basis == "license":
+                serializer = LicenseSerializer(obj)
+            else:
+                serializer = RightsShellSerializer(obj)
         else:
             serializer = RightsGrantedSerializer(obj)
         bytes = JSONRenderer().render(serializer.data)

--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -6,7 +6,7 @@ from rest_framework.renderers import JSONRenderer
 
 from .models import RightsShell
 from .serializers import (CopyrightSerializer, LicenseSerializer,
-                          RightsGrantedSerializer, RightsShellSerializer,
+                          OtherSerializer, RightsGrantedSerializer,
                           StatuteSerializer)
 
 
@@ -86,7 +86,7 @@ class RightsAssembler(object):
             elif obj.rights_basis == "license":
                 serializer = LicenseSerializer(obj)
             else:
-                serializer = RightsShellSerializer(obj)
+                serializer = OtherSerializer(obj)
         else:
             serializer = RightsGrantedSerializer(obj)
         bytes = JSONRenderer().render(serializer.data)

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -56,11 +56,10 @@ class RightsShellSerializer(serializers.ModelSerializer):
 
 class CopyrightSerializer(RightsShellSerializer):
     jurisdiction = serializers.SerializerMethodField()
-    status = serializers.CharField(source="copyright_status")
 
     class Meta:
         model = RightsShell
-        fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'status')
+        fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'copyright_status')
 
     def get_jurisdiction(self, obj):
         return obj.jurisdiction.lower() if obj.jurisdiction else None
@@ -78,8 +77,7 @@ class StatuteSerializer(RightsShellSerializer):
 
 
 class LicenseSerializer(RightsShellSerializer):
-    terms = serializers.CharField(source="license_terms")
 
     class Meta:
         model = RightsShell
-        fields = RightsShellSerializer.Meta.fields + ('terms',)
+        fields = RightsShellSerializer.Meta.fields + ('license_terms',)

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -28,25 +28,58 @@ class RightsShellSerializer(serializers.ModelSerializer):
     """
     start_date = serializers.CharField()
     end_date = serializers.CharField()
-    status = serializers.CharField(source="copyright_status")
-    terms = serializers.CharField(source="license_terms")
+    # terms = serializers.CharField(source="license_terms")
     rights_granted = serializers.ListField(default=[])
-    jurisdiction = serializers.SerializerMethodField()
 
     class Meta:
         model = RightsShell
         fields = (
             "rights_basis",
-            "determination_date",
-            "jurisdiction",
             "start_date",
             "end_date",
             "note",
-            "status",
-            "terms",
-            "statute_citation",
             "rights_granted"
         )
+        # fields = (
+        #     "rights_basis",
+        #     "determination_date",
+        #     "jurisdiction",
+        #     "start_date",
+        #     "end_date",
+        #     "note",
+        #     "status",
+        #     "terms",
+        #     "statute_citation",
+        #     "rights_granted"
+        # )
+
+
+class CopyrightSerializer(RightsShellSerializer):
+    jurisdiction = serializers.SerializerMethodField()
+    status = serializers.CharField(source="copyright_status")
+
+    class Meta:
+        model = RightsShell
+        fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'status')
 
     def get_jurisdiction(self, obj):
         return obj.jurisdiction.lower() if obj.jurisdiction else None
+
+
+class StatuteSerializer(RightsShellSerializer):
+    jurisdiction = serializers.SerializerMethodField()
+
+    class Meta:
+        model = RightsShell
+        fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'statute_citation')
+
+    def get_jurisdiction(self, obj):
+        return obj.jurisdiction.lower() if obj.jurisdiction else None
+
+
+class LicenseSerializer(RightsShellSerializer):
+    terms = serializers.CharField(source="license_terms")
+
+    class Meta:
+        model = RightsShell
+        fields = RightsShellSerializer.Meta.fields + ('terms',)

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -41,6 +41,21 @@ class RightsShellSerializer(serializers.ModelSerializer):
         )
 
 
+class OtherSerializer(RightsShellSerializer):
+    rights_basis = serializers.SerializerMethodField()
+    other_basis = serializers.SerializerMethodField()
+
+    class Meta:
+        model = RightsShell
+        fields = RightsShellSerializer.Meta.fields + ('other_basis',)
+
+    def get_rights_basis(self, obj):
+        return "other"
+
+    def get_other_basis(self, obj):
+        return obj.rights_basis
+
+
 class CopyrightSerializer(RightsShellSerializer):
     jurisdiction = serializers.SerializerMethodField()
 

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -29,6 +29,7 @@ class RightsShellSerializer(serializers.ModelSerializer):
     start_date = serializers.CharField()
     end_date = serializers.CharField()
     rights_granted = serializers.ListField(default=[])
+    jurisdiction = serializers.SerializerMethodField()
 
     class Meta:
         model = RightsShell
@@ -39,6 +40,9 @@ class RightsShellSerializer(serializers.ModelSerializer):
             "note",
             "rights_granted"
         )
+
+    def get_jurisdiction(self, obj):
+        return obj.jurisdiction.lower() if obj.jurisdiction else None
 
 
 class OtherSerializer(RightsShellSerializer):
@@ -57,25 +61,17 @@ class OtherSerializer(RightsShellSerializer):
 
 
 class CopyrightSerializer(RightsShellSerializer):
-    jurisdiction = serializers.SerializerMethodField()
 
     class Meta:
         model = RightsShell
         fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'copyright_status')
 
-    def get_jurisdiction(self, obj):
-        return obj.jurisdiction.lower() if obj.jurisdiction else None
-
 
 class StatuteSerializer(RightsShellSerializer):
-    jurisdiction = serializers.SerializerMethodField()
 
     class Meta:
         model = RightsShell
         fields = RightsShellSerializer.Meta.fields + ('determination_date', 'jurisdiction', 'statute_citation')
-
-    def get_jurisdiction(self, obj):
-        return obj.jurisdiction.lower() if obj.jurisdiction else None
 
 
 class LicenseSerializer(RightsShellSerializer):

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -30,7 +30,6 @@ class RightsShellSerializer(serializers.ModelSerializer):
     end_date = serializers.CharField()
     status = serializers.CharField(source="copyright_status")
     terms = serializers.CharField(source="license_terms")
-    citation = serializers.CharField(source="statute_citation")
     rights_granted = serializers.ListField(default=[])
     jurisdiction = serializers.SerializerMethodField()
 
@@ -45,7 +44,7 @@ class RightsShellSerializer(serializers.ModelSerializer):
             "note",
             "status",
             "terms",
-            "citation",
+            "statute_citation",
             "rights_granted"
         )
 

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -40,18 +40,6 @@ class RightsShellSerializer(serializers.ModelSerializer):
             "note",
             "rights_granted"
         )
-        # fields = (
-        #     "rights_basis",
-        #     "determination_date",
-        #     "jurisdiction",
-        #     "start_date",
-        #     "end_date",
-        #     "note",
-        #     "status",
-        #     "terms",
-        #     "statute_citation",
-        #     "rights_granted"
-        # )
 
 
 class CopyrightSerializer(RightsShellSerializer):

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -47,7 +47,7 @@ class RightsShellSerializer(serializers.ModelSerializer):
 
 class OtherSerializer(RightsShellSerializer):
     rights_basis = serializers.SerializerMethodField()
-    other_basis = serializers.SerializerMethodField()
+    other_basis = serializers.CharField(source='rights_basis')
 
     class Meta:
         model = RightsShell
@@ -55,9 +55,6 @@ class OtherSerializer(RightsShellSerializer):
 
     def get_rights_basis(self, obj):
         return "other"
-
-    def get_other_basis(self, obj):
-        return obj.rights_basis
 
 
 class CopyrightSerializer(RightsShellSerializer):

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -28,7 +28,6 @@ class RightsShellSerializer(serializers.ModelSerializer):
     """
     start_date = serializers.CharField()
     end_date = serializers.CharField()
-    # terms = serializers.CharField(source="license_terms")
     rights_granted = serializers.ListField(default=[])
 
     class Meta:

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -57,11 +57,10 @@ def set_dates():
     return start_date, end_date, start_date_period, end_date_period, end_date_open
 
 
-def add_rights_shells(count=15):
-    for x in range(count):
+def add_rights_shells():
+    for basis in ["copyright", "policy", "donor", "statute", "license", "copyright", "donor", "policy", "copyright"]:
         start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
         new_shell = RightsShell(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
-        basis = random.choice(["copyright", "policy", "donor", "statute", "license"])
         new_shell.rights_basis = basis
         if basis in ["copyright", "statute"]:
             new_shell.jurisdiction = "US"

--- a/assign_rights/test_helpers.py
+++ b/assign_rights/test_helpers.py
@@ -58,7 +58,7 @@ def set_dates():
 
 
 def add_rights_shells():
-    for basis in ["copyright", "policy", "donor", "statute", "license", "copyright", "donor", "policy", "copyright"]:
+    for basis in ["copyright", "policy", "donor", "statute", "license"]:
         start_date, end_date, start_date_period, end_date_period, end_date_open = set_dates()
         new_shell = RightsShell(determination_date=random_date(10, 0), note=random_string(), start_date=start_date, end_date=end_date, start_date_period=start_date_period, end_date_period=end_date_period, end_date_open=end_date_open)
         new_shell.rights_basis = basis

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -221,7 +221,6 @@ class TestRightsAssembler(TestCase):
         """Tests that Serialzers are working as expected."""
         for obj_cls in [RightsShell, RightsGranted]:
             obj = random.choice(obj_cls.objects.all())
-
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, start_date, end_date)

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -14,7 +14,6 @@ from rest_framework.test import APIRequestFactory
 from .assemble import RightsAssembler
 from .forms import GroupingForm, RightsShellForm
 from .models import Grouping, RightsGranted, RightsShell, User
-from .serializers import RightsGrantedSerializer, RightsShellSerializer
 from .test_helpers import (add_groupings, add_rights_acts, add_rights_shells,
                            random_date, random_string)
 from .views import (GroupingCreateView, GroupingDetailView, GroupingListView,
@@ -219,15 +218,15 @@ class TestRightsAssembler(TestCase):
 
     def test_create_json(self):
         """Tests that Serialzers are working as expected."""
-        for obj_cls, serializer_cls in [
-                (RightsShell, RightsShellSerializer),
-                (RightsGranted, RightsGrantedSerializer)]:
+        for obj_cls in [RightsShell, RightsGranted]:
             obj = random.choice(obj_cls.objects.all())
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, start_date, end_date)
             if obj_cls == RightsShell:
-                if obj.jurisdiction:
+                if obj.rights_basis == "copyright" and obj.jurisdiction:
+                    print(obj.jurisdiction)
+                    print(serialized)
                     self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))
             self.assertEqual(start_date, serialized["start_date"])

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -225,7 +225,7 @@ class TestRightsAssembler(TestCase):
             obj = random.choice(obj_cls.objects.all())
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
-            serialized = self.assembler.create_json(obj, serializer_cls, start_date, end_date)
+            serialized = self.assembler.create_json(obj, start_date, end_date)
             if obj_cls == RightsShell:
                 if obj.jurisdiction:
                     self.assertTrue(serialized['jurisdiction'].islower())

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -231,7 +231,7 @@ class TestRightsAssembler(TestCase):
                 else:
                     basis_json = "{}_basis.json".format(obj.rights_basis)
                     self.assertTrue(is_valid(serialized, basis_json))
-                if obj.rights_basis == "copyright" and obj.jurisdiction:
+                if obj.jurisdiction:
                     self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))
             self.assertEqual(start_date, serialized["start_date"])

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -230,7 +230,7 @@ class TestRightsAssembler(TestCase):
                     basis_json = "other_basis.json"
                 else:
                     basis_json = "{}_basis.json".format(obj.rights_basis)
-                    self.assertTrue(is_valid(serialized, basis_json))
+                self.assertTrue(is_valid(serialized, basis_json))
                 if obj.jurisdiction:
                     self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -217,21 +217,28 @@ class TestRightsAssembler(TestCase):
         for granted in shell.rightsgranted_set.all():
             self.check_object_dates(granted, request_start_date, request_end_date)
 
-    def test_create_json(self):
-        """Tests that Serialzers are working as expected."""
-        for obj_cls in [RightsShell, RightsGranted]:
-            obj = random.choice(obj_cls.objects.all())
+    def test_create_basis_json(self):
+        """Tests that Rights Shell Serializers are working as expected."""
+        for basis in ["copyright", "policy", "donor", "statute", "license"]:
+            obj = random.choice(RightsShell.objects.filter(rights_basis=basis))
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, start_date, end_date)
-            if obj_cls == RightsShell:
-                if obj.rights_basis in ["policy", "donor"]:
-                    basis_json = "other_basis.json"
-                else:
-                    basis_json = "{}_basis.json".format(obj.rights_basis)
-                self.assertTrue(is_valid(serialized, basis_json))
-                if obj.jurisdiction:
-                    self.assertTrue(serialized['jurisdiction'].islower())
+            if obj.rights_basis in ["policy", "donor"]:
+                basis_json = "other_basis.json"
+            else:
+                basis_json = "{}_basis.json".format(obj.rights_basis)
+            self.assertTrue(is_valid(serialized, basis_json))
+            if obj.jurisdiction:
+                self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))
-            self.assertEqual(start_date, serialized["start_date"])
-            self.assertEqual(end_date, serialized["end_date"])
+
+    def test_create_granted_json(self):
+        """Tests that Rights Granted Serializer is working as expected."""
+        obj = random.choice(RightsGranted.objects.all())
+        start_date = random_date(75, 50).isoformat()
+        end_date = random_date(49, 5).isoformat()
+        serialized = self.assembler.create_json(obj, start_date, end_date)
+        self.assertTrue(isinstance(serialized, dict))
+        self.assertEqual(start_date, serialized["start_date"])
+        self.assertEqual(end_date, serialized["end_date"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ PyJWT==2.0.1
 python-dateutil==2.8.1
 pytz==2021.1
 PyYAML==5.4.1
+rac_schemas=0.26
 requests==2.25.1
 six==1.15.0
 smmap==3.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ PyJWT==2.0.1
 python-dateutil==2.8.1
 pytz==2021.1
 PyYAML==5.4.1
-rac_schemas=0.26
+rac_schemas==0.26
 requests==2.25.1
 six==1.15.0
 smmap==3.0.5


### PR DESCRIPTION
Adds "other" serializer which returns a rights basis of "other" and an other basis of "policy" or "donor."

Fixes #124. Fixes #47.

Note: should be merged after #144.