### PR TITLE
Replace buttons with cards

### DIFF
--- a/assign_rights/static/css/custom.css
+++ b/assign_rights/static/css/custom.css
@@ -66,3 +66,7 @@ a.btn {
 .fixed-height {
   max-height: 250px;
 }
+
+.full-height {
+  height: 100%;
+}

--- a/assign_rights/templates/index.html
+++ b/assign_rights/templates/index.html
@@ -24,7 +24,7 @@
     <div class="card full-height">
       <div class="card-body">
         <h2>Rights Shells</h2>
-        <p>Rights Shells are structured, machine-actionble statements of what can
+        <p>Rights Shells are structured, machine-actionable statements of what can
           or can't be done with a group of records.
           </p>
       </div>

--- a/assign_rights/templates/index.html
+++ b/assign_rights/templates/index.html
@@ -5,18 +5,35 @@
 <p class="lead">Browse, create and manage record groupings and rights statement shells.</p>
 <div class="row mb-3">
   <div class="col">
-    <a class="btn btn-lg btn-block btn-primary" href="{% url 'groupings-list' %}">Browse groupings</a>
+    <div class="card full-height">
+      <div class="card-body">
+        <h2>Groupings</h2>
+        <p>
+          Groupings are aggregations of records which have the same rights statuses.
+          They do not necessarily equate to record groups, nor are they always from
+          the same source of provenance.
+        </p>
+      </div>
+      <div class="card-footer d-flex justify-content-between">
+        <a class="btn btn-lg btn-secondary" href="{% url 'groupings-list' %}">Browse groupings</a>
+        <a class="btn btn-lg btn-primary" href="{% url 'groupings-create' %}">Create a new grouping</a>
+      </div>
+    </div>
   </div>
   <div class="col">
-    <a class="btn btn-lg btn-block btn-primary" href="{% url 'rights-list' %}">Browse rights shells</a>
+    <div class="card full-height">
+      <div class="card-body">
+        <h2>Rights Shells</h2>
+        <p>Rights Shells are structured, machine-actionble statements of what can
+          or can't be done with a group of records.
+          </p>
+      </div>
+      <div class="card-footer d-flex justify-content-between">
+        <a class="btn btn-lg btn-secondary" href="{% url 'rights-list' %}">Browse rights shells</a>
+        <a class="btn btn-lg btn-primary" href="{% url 'rights-create' %}">Create a new rights shell</a>
+      </div>
+    </div>
   </div>
 </div>
-<div class="row">
-  <div class="col">
-    <a class="btn btn-lg btn-block btn-primary" href="{% url 'groupings-create' %}">Create a new grouping</a>
-  </div>
-  <div class="col">
-    <a class="btn btn-lg btn-block btn-primary" href="{% url 'rights-create' %}">Create a new rights shell</a>
-  </div>
-</div>
+
 {% endblock %}

--- a/assign_rights/templates/index.html
+++ b/assign_rights/templates/index.html
@@ -9,9 +9,9 @@
       <div class="card-body">
         <h2>Groupings</h2>
         <p>
-          Groupings are aggregations of records which have the same rights statuses.
-          They do not necessarily equate to record groups, nor are they always from
-          the same source of provenance.
+          Aggregations of records with the same rights statuses. Groupings don't
+          necessarily equate to record groups, and are not required to be from
+          the same source.
         </p>
       </div>
       <div class="card-footer d-flex justify-content-between">
@@ -24,9 +24,7 @@
     <div class="card full-height">
       <div class="card-body">
         <h2>Rights Shells</h2>
-        <p>Rights Shells are structured, machine-actionable statements of what can
-          or can't be done with a group of records.
-          </p>
+        <p>Structured, machine-actionable statements of what can or can't be done with a group of records.</p>
       </div>
       <div class="card-footer d-flex justify-content-between">
         <a class="btn btn-lg btn-secondary" href="{% url 'rights-list' %}">Browse rights shells</a>


### PR DESCRIPTION
Replaces buttons on home page with cards.

Card text could definitely be improved; would very much welcome suggestions on how to improve it!

Also noting that I've left the "rights shells" terminology intact for now since that's accounted for in a different issue.

fixes #153 