### PR TITLE
Overrides save method to lowercase jurisdiction

### DIFF
--- a/assign_rights/models.py
+++ b/assign_rights/models.py
@@ -39,6 +39,11 @@ class RightsShell(models.Model):
     def get_absolute_url(self):
         return reverse("rights-detail", kwargs={"pk": self.pk})
 
+    def save(self, *args, **kwargs):
+        """Custom save method to coerce jurisdiction to lowercase."""
+        self.jurisdiction = self.jurisdiction.lower() if self.jurisdiction else None
+        super(RightsShell, self).save(*args, **kwargs)
+
     def __str__(self):
         prefixes = [self.get_rights_basis_display()]
         if self.rights_basis == "Copyright":

--- a/assign_rights/serializers.py
+++ b/assign_rights/serializers.py
@@ -29,7 +29,7 @@ class RightsShellSerializer(serializers.ModelSerializer):
     start_date = serializers.CharField()
     end_date = serializers.CharField()
     rights_granted = serializers.ListField(default=[])
-    jurisdiction = serializers.SerializerMethodField()
+    jurisdiction = serializers.CharField()
 
     class Meta:
         model = RightsShell
@@ -40,9 +40,6 @@ class RightsShellSerializer(serializers.ModelSerializer):
             "note",
             "rights_granted"
         )
-
-    def get_jurisdiction(self, obj):
-        return obj.jurisdiction.lower() if obj.jurisdiction else None
 
 
 class OtherSerializer(RightsShellSerializer):

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -219,8 +219,7 @@ class TestRightsAssembler(TestCase):
 
     def test_create_basis_json(self):
         """Tests that Rights Shell Serializers are working as expected."""
-        for basis in ["copyright", "policy", "donor", "statute", "license"]:
-            obj = random.choice(RightsShell.objects.filter(rights_basis=basis))
+        for obj in RightsShell.objects.all():
             start_date = random_date(75, 50).isoformat()
             end_date = random_date(49, 5).isoformat()
             serialized = self.assembler.create_json(obj, start_date, end_date)
@@ -230,6 +229,7 @@ class TestRightsAssembler(TestCase):
                 basis_json = "{}_basis.json".format(obj.rights_basis)
             self.assertTrue(is_valid(serialized, basis_json))
             if obj.jurisdiction:
+                self.assertTrue(obj.jurisdiction.islower())
                 self.assertTrue(serialized['jurisdiction'].islower())
             self.assertTrue(isinstance(serialized, dict))
 


### PR DESCRIPTION
Implements a custom save method which lowercases the `jurisdiction` value if it exists. Removes the serializer code which coerced values to lowercase.

fixes #151 