### PR TITLE
Change "rights shell" to "rights statement"

### DIFF
--- a/assign_rights/assemble.py
+++ b/assign_rights/assemble.py
@@ -14,11 +14,11 @@ class RightsAssembler(object):
     """Assembles and returns a list of rights statements."""
 
     def run(self, rights_ids, request_start_date, request_end_date):
-        """Assembles and returns rights statements given rights shell IDs and
+        """Assembles and returns rights statements given rights statement IDs and
         start and end dates.
 
         Args:
-            rights_ids (list): a list of identifiers for rights shells.
+            rights_ids (list): a list of identifiers for rights statements.
             request_start_date (string): a string representation of the earliest date of a group of records
             request_end_date (string): a string representation of the latest date of a group of records
         """
@@ -36,7 +36,7 @@ class RightsAssembler(object):
         return shell_data
 
     def retrieve_rights(self, rights_ids):
-        """Retrieves rights shells matching identifiers."""
+        """Retrieves rights statements matching identifiers."""
         return [RightsShell.objects.get(pk=ident) for ident in rights_ids]
 
     def get_dates(self, object, request_start_date, request_end_date):

--- a/assign_rights/templates/groupings/detail.html
+++ b/assign_rights/templates/groupings/detail.html
@@ -8,7 +8,7 @@
 
 <p>{{ object.description }}</p>
 
-<h2>Associated Rights Shells</h2>
+<h2>Associated Rights Statements</h2>
 <ul>
   {% for rights in object.rights_shells.all %}<li>{{rights}}</li>{% endfor %}
 </ul>

--- a/assign_rights/templates/groupings/manage.html
+++ b/assign_rights/templates/groupings/manage.html
@@ -8,7 +8,7 @@
 	{{ form.title | as_crispy_field }}
 	{{ form.description | as_crispy_field }}
 	<fieldset>
-		<legend>Choose Associated Rights Shell/s*</legend>
+		<legend>Choose Associated Rights Statement/s*</legend>
 		<div class="overflow-auto border pt-3 px-3 mb-3 fixed-height">
 			{{ form.rights_shells | as_crispy_field }}
 		</div>

--- a/assign_rights/templates/index.html
+++ b/assign_rights/templates/index.html
@@ -23,14 +23,14 @@
   <div class="col">
     <div class="card full-height">
       <div class="card-body">
-        <h2>Rights Shells</h2>
-        <p>Rights Shells are structured, machine-actionable statements of what can
+        <h2>Rights Statements</h2>
+        <p>Rights Statements are structured, machine-actionable statements of what can
           or can't be done with a group of records.
           </p>
       </div>
       <div class="card-footer d-flex justify-content-between">
-        <a class="btn btn-lg btn-secondary" href="{% url 'rights-list' %}">Browse rights shells</a>
-        <a class="btn btn-lg btn-primary" href="{% url 'rights-create' %}">Create a new rights shell</a>
+        <a class="btn btn-lg btn-secondary" href="{% url 'rights-list' %}">Browse rights statements</a>
+        <a class="btn btn-lg btn-primary" href="{% url 'rights-create' %}">Create a new rights statement</a>
       </div>
     </div>
   </div>

--- a/assign_rights/templates/navbar.html
+++ b/assign_rights/templates/navbar.html
@@ -15,7 +15,7 @@
           <a class="nav-link text-light" href="{% url 'groupings-list' %}">Groupings</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link text-light" href="{% url 'rights-list' %}">Rights Shells</a>
+          <a class="nav-link text-light" href="{% url 'rights-list' %}">Rights Statements</a>
         </li>
         <li class="nav-item">
           <a class="nav-link text-light" href="{% url 'rights-assemble' %}">Rights Assembler API</a>

--- a/assign_rights/templates/rights/list.html
+++ b/assign_rights/templates/rights/list.html
@@ -3,7 +3,7 @@
 
 {% block header_button %}
   {% if request.user|has_group:"edit" %}
-  <a class="btn btn-primary mt-2 float-right" href="{% url 'rights-create' %}">Create new rights shell</a>
+  <a class="btn btn-primary mt-2 float-right" href="{% url 'rights-create' %}">Create new rights statement</a>
   {% endif %}
 {% endblock %}
 

--- a/assign_rights/tests.py
+++ b/assign_rights/tests.py
@@ -50,7 +50,7 @@ class TestRightsAssemblyView(TransactionTestCase):
 
         # RightsAssembler throws an exception
         for fixture_name, message, status_code in [
-                ("invalid_rights_id.json", "Error retrieving rights shell: RightsShell matching query does not exist.", 404),
+                ("invalid_rights_id.json", "Error retrieving rights statement: RightsShell matching query does not exist.", 404),
                 ("no_start_date.json", "Request data must contain 'identifiers', 'start_date' and 'end_date' keys.", 400)]:
             with open(join(invalid_data_fixture_dir, fixture_name), 'r') as json_file:
                 invalid_data = json.load(json_file)
@@ -218,7 +218,7 @@ class TestRightsAssembler(TestCase):
             self.check_object_dates(granted, request_start_date, request_end_date)
 
     def test_create_basis_json(self):
-        """Tests that Rights Shell Serializers are working as expected."""
+        """Tests that Rights Statement Serializers are working as expected."""
         for basis in ["copyright", "policy", "donor", "statute", "license"]:
             obj = random.choice(RightsShell.objects.filter(rights_basis=basis))
             start_date = random_date(75, 50).isoformat()

--- a/assign_rights/views.py
+++ b/assign_rights/views.py
@@ -37,18 +37,18 @@ class HomePage(PageTitleMixin, LoginRequiredMixin, TemplateView):
 
 
 class RightsShellListView(PageTitleMixin, LoginRequiredMixin, ListView):
-    """Browse and search rights shells."""
+    """Browse and search rights statements."""
     model = RightsShell
     template_name = "rights/list.html"
-    page_title = "Rights Shells"
+    page_title = "Rights Statements"
 
 
 class RightsShellCreateView(PageTitleMixin, EditMixin, CreateView):
-    """Create a rights shell. Only available to 'edit' group."""
+    """Create a rights statement. Only available to 'edit' group."""
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellForm
-    page_title = "Create New Rights Shell"
+    page_title = "Create New Rights Statement"
 
     def get_context_data(self, **kwargs):
         """Load specific rights basis form based on logic in rights create template. Returns subclass of RightsShellForm"""
@@ -87,7 +87,7 @@ class RightsShellCreateView(PageTitleMixin, EditMixin, CreateView):
 
 
 class RightsShellUpdateView(PageTitleMixin, EditMixin, UpdateView):
-    """Update a rights shell. Only available to 'edit' group."""
+    """Update a rights statement. Only available to 'edit' group."""
     model = RightsShell
     template_name = "rights/manage.html"
     form_class = RightsShellUpdateForm
@@ -135,7 +135,7 @@ class RightsShellUpdateView(PageTitleMixin, EditMixin, UpdateView):
 
 
 class RightsShellDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
-    """Delete a rights shell."""
+    """Delete a rights statement."""
     model = RightsShell
     template_name = "rights/confirm_delete.html"
     page_title = "Confirm Delete"
@@ -143,7 +143,7 @@ class RightsShellDeleteView(PageTitleMixin, DeleteMixin, DeleteView):
 
 
 class RightsShellDetailView(PageTitleMixin, LoginRequiredMixin, DetailView):
-    """View a rights shell."""
+    """View a rights statement."""
     model = RightsShell
     template_name = "rights/detail.html"
 
@@ -213,7 +213,7 @@ class RightsAssemblerView(APIView):
             rights = RightsAssembler().run(rights_ids, request_start_date, request_end_date)
             return Response({"rights_statements": rights}, status=200)
         except RightsShell.DoesNotExist as e:
-            return Response({"detail": "Error retrieving rights shell: {}".format(str(e))}, status=404)
+            return Response({"detail": "Error retrieving rights statement: {}".format(str(e))}, status=404)
         except ValueError as e:
             return Response({"detail": "Unable to parse date: {}".format(e)}, status=500)
         except Exception as e:


### PR DESCRIPTION
Changes all mentions of "rights shell(s)" to "rights statement(s)". This is branched from #154 and should be merged after.

Fixes #152 