### PR TITLE
Render linebreaks in HTML

### DIFF
--- a/assign_rights/templates/groupings/detail.html
+++ b/assign_rights/templates/groupings/detail.html
@@ -6,7 +6,7 @@
 <small>Created on {{ object.created }}</small><br/>
 <small>Last modified on {{ object.last_modified }}</small>
 
-<p>{{ object.description }}</p>
+<p>{{ object.description | linebreaks }}</p>
 
 <h2>Associated Rights Statements</h2>
 <ul>

--- a/assign_rights/templates/groupings/list.html
+++ b/assign_rights/templates/groupings/list.html
@@ -20,7 +20,7 @@
     {% for object in object_list %}
     <tr>
       <td><a href="{% url 'groupings-detail' pk=object.pk %}">{{ object.title  }}</a></td>
-      <td>{{ object.description }}</td>
+      <td>{{ object.description | linebreaks }}</td>
       <td>{% for rights in object.rights_shells.all %}{{rights}}{% if not forloop.last %}<br/>{% endif %}{% endfor %}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Uses the Django template tag [linebreaks](https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#linebreaks) to add HTML line breaks.

Fixes #163 