### PR TITLE
Underline navigation links on hover

### DIFF
--- a/assign_rights/static/css/custom.css
+++ b/assign_rights/static/css/custom.css
@@ -70,3 +70,7 @@ a.btn {
 .full-height {
   height: 100%;
 }
+
+.nav-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Underlines navigation links on hover. This seemed to be the cleanest intervention here - changing the color of the text on hover while still meeting accessibility baselines for color contrast was challenging, and the spacing between nav items is tied into responsiveness of the navbar as a whole, so I took the old-school approach here.

fixes #157 