### PR TITLE
Hides create buttons on home page from users without write privileges

### DIFF
--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -159,3 +159,5 @@ LOGIN_REDIRECT_URL = "home"
 
 # django-crispy-forms template pack
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/assign_rights/templates/index.html
+++ b/assign_rights/templates/index.html
@@ -17,7 +17,9 @@
         </div>
         <div class="card__buttons">
           <a class="btn btn-secondary btn-block" href="{% url 'groupings-list' %}">Browse groupings</a>
+          {% if request.user|has_group:"edit" %}
           <a class="btn btn-primary btn-block " href="{% url 'groupings-create' %}">Create a new grouping</a>
+          {% endif %}
         </div>
       </div>
     </div>
@@ -31,7 +33,9 @@
         </div>
         <div class="card__buttons">
           <a class="btn btn-secondary btn-block" href="{% url 'rights-list' %}">Browse rights statements</a>
+          {% if request.user|has_group:"edit" %}
           <a class="btn btn-primary btn-block" href="{% url 'rights-create' %}">Create a new rights statement</a>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/assign_rights/templatetags/utils.py
+++ b/assign_rights/templatetags/utils.py
@@ -14,7 +14,10 @@ def has_group(user, group_name):
     Returns:
         boolean: True or False depending on whether user belongs to a group.
     """
-    return user.groups.filter(name=group_name).exists()
+    if user.is_superuser:
+        return True
+    else:
+        return user.groups.filter(name=group_name).exists()
 
 
 @register.filter


### PR DESCRIPTION
Hides the "create" buttons on the home page if users do not have edit permissions.

Also updates the `has_group` template tag so that superusers can see everything, as would be expected, and adds the `DEFAULT_AUTO_FIELD` value to the config.

Fixes #170 