### PR TITLE
Prep for Google Analytics

### DIFF
--- a/aquila/config.py.deploy
+++ b/aquila/config.py.deploy
@@ -13,3 +13,5 @@ SSO_AUDIENCE = "${SSO_AUDIENCE}"
 LOGIN_URL = "django_auth_adfs:login"
 SUPERUSER_USERNAME = "${SUPERUSER_USERNAME}"
 SUPERUSER_EMAIL = "${SUPERUSER_EMAIL}"
+# Google analytics configs
+GTM_ID = "${GTM_ID}"

--- a/aquila/config.py.example
+++ b/aquila/config.py.example
@@ -13,3 +13,4 @@ SSO_AUDIENCE = "microsoft:identityserver:http://aquila-web:8009"
 LOGIN_URL = "login"
 SUPERUSER_USERNAME = "test"
 SUPERUSER_EMAIL = "test@example.com"
+GTM_ID = 'GTM-xxxxxxx'

--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -163,3 +163,6 @@ LOGIN_REDIRECT_URL = "home"
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Google Analytics configs
+GTM_ID = config.GTM_ID

--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -70,6 +70,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'assign_rights.context_processors.gtm_id',
             ],
         },
     },

--- a/assign_rights/context_processors.py
+++ b/assign_rights/context_processors.py
@@ -1,0 +1,7 @@
+# assign_rights/context_processors.py
+
+from django.conf import settings
+
+
+def gtm_id(request):
+    return {'gtm_id': settings.GTM_ID}

--- a/assign_rights/templates/base.html
+++ b/assign_rights/templates/base.html
@@ -6,6 +6,10 @@
     {% block extra_css %}{% endblock %}
   </head>
   <body>
+  <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
     <a href="#main" class="skip-link visually-hidden">Jump directly to main content</a>
     <div class="wrapper">
 

--- a/assign_rights/templates/head.html
+++ b/assign_rights/templates/head.html
@@ -11,6 +11,14 @@
 
 <link rel="icon" type="image/png" href="{% static "img/favicon.ico" %}">
 
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ gtm_id }}');</script>
+<!-- End Google Tag Manager -->
+
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
 <!--[if lt IE 9]>


### PR DESCRIPTION
Fixes #175 

Since this is deployed continuously, we'll want to set up the GTM ID in Travis before merging. @HaSistrunk is it correct that we can use a dummy ID for dev? And where can I find the GTM ID for prod? I just did a quick spin through the docs site and Teams and couldn't find anything.