### PR TITLE
Update dependencies and fix readme build status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aquila
 
-[![Build Status](https://travis-ci.org/RockefellerArchiveCenter/aquila.svg?branch=base)](https://travis-ci.org/RockefellerArchiveCenter/aquila)
+[![Build Status](https://travis-ci.com/RockefellerArchiveCenter/aquila.svg?branch=base)](https://travis-ci.com/RockefellerArchiveCenter/aquila)
 
 An application to store, calculate, and assign PREMIS rights statements.
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
-Django==3.2.10
-django-auth-adfs==1.9.3
+Django==3.2.11
+django-auth-adfs==1.9.4
 django-crispy-forms==1.13.0
-djangorestframework==3.12.4
+djangorestframework==3.13.1
 health-check==3.4.1
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
 python-dateutil==2.8.2
 rac_schemas==0.29
-requests==2.26.0
+requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 asgiref==3.4.1
     # via django
-attrs==21.2.0
+attrs==21.4.0
     # via jsonschema
 certifi==2021.10.8
     # via requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
     # via requests
 clinner==1.12.3
     # via health-check
@@ -20,16 +20,16 @@ colorlog==3.2.0
     # via clinner
 cryptography==36.0.1
     # via django-auth-adfs
-django==3.2.10
+django==3.2.11
     # via
     #   -r requirements.in
     #   django-auth-adfs
     #   djangorestframework
-django-auth-adfs==1.9.3
+django-auth-adfs==1.9.4
     # via -r requirements.in
 django-crispy-forms==1.13.0
     # via -r requirements.in
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via -r requirements.in
 gitdb==4.0.9
     # via gitpython
@@ -39,11 +39,11 @@ health-check==3.4.1
     # via -r requirements.in
 idna==3.3
     # via requests
-importlib-metadata==4.8.2
+importlib-metadata==4.8.3
     # via jsonschema
 jsonschema==3.2.0
     # via rac-schemas
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via -r requirements.in
 pycparser==2.21
     # via cffi
@@ -54,12 +54,14 @@ pyrsistent==0.18.0
 python-dateutil==2.8.2
     # via -r requirements.in
 pytz==2021.3
-    # via django
+    # via
+    #   django
+    #   djangorestframework
 pyyaml==6.0
     # via health-check
 rac_schemas==0.29
     # via -r requirements.in
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements.in
     #   django-auth-adfs
@@ -76,7 +78,7 @@ typing-extensions==4.0.1
     #   asgiref
     #   gitpython
     #   importlib-metadata
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   django-auth-adfs
     #   requests


### PR DESCRIPTION
- Updates django-auth-adfs, djangorestframework, psycopg2-binary, and requests.
- Updates to Django 3.2.11, but holding off on updating to 4.0.1 because we are using python 3.6.
- Uses travis.com instead of travis.org in readme build status url