### PR TITLE
Replace Google with Matomo Tag Manager for Analytics

### DIFF
--- a/aquila/config.py.deploy
+++ b/aquila/config.py.deploy
@@ -13,5 +13,5 @@ SSO_AUDIENCE = "${SSO_AUDIENCE}"
 LOGIN_URL = "django_auth_adfs:login"
 SUPERUSER_USERNAME = "${SUPERUSER_USERNAME}"
 SUPERUSER_EMAIL = "${SUPERUSER_EMAIL}"
-# Google analytics configs
-GTM_ID = "${GTM_ID}"
+# Matomo analytics configs
+MTM_ID = "${MTM_ID}"

--- a/aquila/config.py.example
+++ b/aquila/config.py.example
@@ -13,4 +13,4 @@ SSO_AUDIENCE = "microsoft:identityserver:http://aquila-web:8009"
 LOGIN_URL = "login"
 SUPERUSER_USERNAME = "test"
 SUPERUSER_EMAIL = "test@example.com"
-GTM_ID = 'GTM-xxxxxxx'
+MTM_ID = xxxxxxxx

--- a/aquila/config.py.example
+++ b/aquila/config.py.example
@@ -13,4 +13,4 @@ SSO_AUDIENCE = "microsoft:identityserver:http://aquila-web:8009"
 LOGIN_URL = "login"
 SUPERUSER_USERNAME = "test"
 SUPERUSER_EMAIL = "test@example.com"
-MTM_ID = https://cdn.matomo.cloud/rockarch.matomo.cloud/container_xxxxxxxx.js
+MTM_ID = 'https://cdn.matomo.cloud/rockarch.matomo.cloud/container_xxxxxxxx.js'

--- a/aquila/config.py.example
+++ b/aquila/config.py.example
@@ -13,4 +13,4 @@ SSO_AUDIENCE = "microsoft:identityserver:http://aquila-web:8009"
 LOGIN_URL = "login"
 SUPERUSER_USERNAME = "test"
 SUPERUSER_EMAIL = "test@example.com"
-MTM_ID = xxxxxxxx
+MTM_ID = https://cdn.matomo.cloud/rockarch.matomo.cloud/container_xxxxxxxx.js

--- a/aquila/settings.py
+++ b/aquila/settings.py
@@ -70,7 +70,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'assign_rights.context_processors.gtm_id',
+                'assign_rights.context_processors.mtm_id',
             ],
         },
     },
@@ -165,5 +165,5 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
-# Google Analytics configs
-GTM_ID = config.GTM_ID
+# Matomo Analytics configs
+MTM_ID = config.MTM_ID

--- a/assign_rights/context_processors.py
+++ b/assign_rights/context_processors.py
@@ -3,5 +3,5 @@
 from django.conf import settings
 
 
-def gtm_id(request):
-    return {'gtm_id': settings.GTM_ID}
+def mtm_id(request):
+    return {'mtm_id': settings.MTM_ID}

--- a/assign_rights/templates/base.html
+++ b/assign_rights/templates/base.html
@@ -6,10 +6,6 @@
     {% block extra_css %}{% endblock %}
   </head>
   <body>
-  <!-- Google Tag Manager (noscript) -->
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}"
-        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
     <a href="#main" class="skip-link visually-hidden">Jump directly to main content</a>
     <div class="wrapper">
 

--- a/assign_rights/templates/head.html
+++ b/assign_rights/templates/head.html
@@ -16,7 +16,7 @@
   var _mtm = window._mtm = window._mtm || [];
   _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-  g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_{{ mtm_id }}.js'; s.parentNode.insertBefore(g,s);
+  g.async=true; g.src='{{ mtm_id }}'; s.parentNode.insertBefore(g,s);
   </script>
   <!-- End Matomo Tag Manager -->
 

--- a/assign_rights/templates/head.html
+++ b/assign_rights/templates/head.html
@@ -11,13 +11,14 @@
 
 <link rel="icon" type="image/png" href="{% static "img/favicon.ico" %}">
 
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ gtm_id }}');</script>
-<!-- End Google Tag Manager -->
+<!-- Matomo Tag Manager -->
+<script>
+  var _mtm = window._mtm = window._mtm || [];
+  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_{{ mtm_id }}.js'; s.parentNode.insertBefore(g,s);
+  </script>
+  <!-- End Matomo Tag Manager -->
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
Fixes #251 

Replaces Google Tag Manager implementation with Matomo Tag Manager tracking. Includes replacement of tracking id variable in Travis for deployment.