### PR TITLE
Fixing rights detail layout issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install [Docker](https://store.docker.com/search?type=edition&offering=community
     $ cd aquila
     $ docker-compose up
 
-A default user with username `test` and password `testpassword` is created on setup. Once the application starts successfully, you should be able to access the application in your browser at `http://localhost:8009`.
+A default user with username `test` and password `testpassword` is created on setup. Once the application starts successfully, you should be able to access the application in your browser at `http://localhost:80`.
 
 When you're done, shut down docker-compose
 

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -89,7 +89,7 @@
 
     {% for rights_granted in rightsshell.rightsgranted_set.all %}
     <div class="card card--container mb-10">
-      <div class="card-body">
+      <div class="card__body">
         <h3 class="card__title">{{rights_granted}}</h3>
         {% if rights_granted.granted_note %}
         <p>{{rights_granted.granted_note}}</p>

--- a/assign_rights/templates/rights/detail.html
+++ b/assign_rights/templates/rights/detail.html
@@ -71,10 +71,10 @@
       </div>
       {% endif %}
       {% if rightsshell.end_date_open %}
-      <div class="summary-list__row"></div>
+      <div class="summary-list__row">
         <dt class="summary-list__key">End Date Open?</dt>
         <dd class="summary-list__value">{{ rightsshell.end_date_open }}</dd>
-      </dl>
+      </div>
       {% endif %}
       {% if rightsshell.end_date_period %}
       <div class="summary-list__row">
@@ -134,10 +134,8 @@
         </dl>
       </div>
     </div>
-  </div>
-</div>
-{% endfor %}
-{% endif %}
+    {% endfor %}
+    {% endif %}
 
 {% if request.user.is_authenticated %}
 <a class="btn btn--sm btn--blue" href="{% url 'rights-update' pk=object.pk %}">Edit</a>


### PR DESCRIPTION
Corrects HTML on rights detail page so that rights statements with multiple acts now display as expected. Screenshot below.
<img width="593" height="617" alt="image" src="https://github.com/user-attachments/assets/25a0b7f4-a877-4e3d-913a-a3cf18f4af7d" />